### PR TITLE
Allow <> style not-equals

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -68,6 +68,9 @@ func (s *Scanner) Scan() (pos Pos, token Token, lit string) {
 			} else if s.peek() == '<' {
 				s.read()
 				return pos, LSHIFT, "<<"
+			} else if s.peek() == '>' {
+				s.read()
+				return pos, NE, "<>"
 			}
 			return pos, LT, "<"
 		case '>':

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -121,6 +121,7 @@ func TestScanner_Scan(t *testing.T) {
 	})
 	t.Run("NE", func(t *testing.T) {
 		AssertScan(t, "!=", sql.NE, "!=")
+		AssertScan(t, "<>", sql.NE, "<>")
 	})
 	t.Run("BITNOT", func(t *testing.T) {
 		AssertScan(t, "!", sql.BITNOT, "!")


### PR DESCRIPTION
Allows both `!=` and `<>` forms of not-equals.

Related to #18 