### PR TITLE
Allow NOT unary expression

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -1484,6 +1484,8 @@ func (expr *UnaryExpr) String() string {
 		return "+" + expr.X.String()
 	case MINUS:
 		return "-" + expr.X.String()
+	case NOT:
+		return "NOT " + expr.X.String()
 	default:
 		panic(fmt.Sprintf("sql.UnaryExpr.String(): invalid op %s", expr.Op))
 	}

--- a/ast_test.go
+++ b/ast_test.go
@@ -861,6 +861,7 @@ func TestParenExpr_String(t *testing.T) {
 func TestUnaryExpr_String(t *testing.T) {
 	AssertExprStringer(t, &sql.UnaryExpr{Op: sql.PLUS, X: &sql.NumberLit{Value: "100"}}, `+100`)
 	AssertExprStringer(t, &sql.UnaryExpr{Op: sql.MINUS, X: &sql.NumberLit{Value: "100"}}, `-100`)
+	AssertExprStringer(t, &sql.UnaryExpr{Op: sql.NOT, X: &sql.NumberLit{Value: "100"}}, `NOT 100`)
 	AssertNodeStringerPanic(t, &sql.UnaryExpr{X: &sql.NumberLit{Value: "100"}}, `sql.UnaryExpr.String(): invalid op ILLEGAL`)
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -3113,6 +3113,7 @@ func TestParser_ParseExpr(t *testing.T) {
 	})
 	t.Run("UnaryExpr", func(t *testing.T) {
 		AssertParseExpr(t, `-123`, &sql.UnaryExpr{OpPos: pos(0), Op: sql.MINUS, X: &sql.NumberLit{ValuePos: pos(1), Value: `123`}})
+		AssertParseExpr(t, `NOT foo`, &sql.UnaryExpr{OpPos: pos(0), Op: sql.NOT, X: &sql.Ident{NamePos: pos(4), Name: "foo"}})
 		AssertParseExprError(t, `-`, `1:1: expected expression, found 'EOF'`)
 	})
 	t.Run("QualifiedRef", func(t *testing.T) {
@@ -3152,7 +3153,7 @@ func TestParser_ParseExpr(t *testing.T) {
 			},
 			Rparen: pos(20),
 		})
-		AssertParseExprError(t, `NOT`, `1:3: expected EXISTS, found 'EOF'`)
+		AssertParseExprError(t, `NOT`, `1:3: expected expression, found 'EOF'`)
 		AssertParseExprError(t, `EXISTS`, `1:6: expected left paren, found 'EOF'`)
 		AssertParseExprError(t, `EXISTS (`, `1:8: expected SELECT or VALUES, found 'EOF'`)
 		AssertParseExprError(t, `EXISTS (SELECT`, `1:14: expected expression, found 'EOF'`)


### PR DESCRIPTION
Allows `NOT foo` expressions.

Related to #18