### PR TITLE
Allow certain keywords to be used as identifiers

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -355,8 +355,7 @@ func (p *Parser) parseCreateTableStatement(createPos Pos) (_ *CreateTableStateme
 func (p *Parser) parseColumnDefinitions() (_ []*ColumnDefinition, err error) {
 	var columns []*ColumnDefinition
 	for {
-		switch {
-		case isIdentToken(p.peek()):
+		if tok := p.peek(); isIdentToken(tok) || isBareToken(tok) {
 			col, err := p.parseColumnDefinition()
 			columns = append(columns, col)
 			if err != nil {
@@ -365,9 +364,9 @@ func (p *Parser) parseColumnDefinitions() (_ []*ColumnDefinition, err error) {
 			if p.peek() == COMMA {
 				p.scan()
 			}
-		case p.peek() == RP || isConstraintStartToken(p.peek(), true):
+		} else if tok == RP || isConstraintStartToken(tok, true) {
 			return columns, nil
-		default:
+		} else {
 			return columns, p.errorExpected(p.pos, p.tok, "column name, CONSTRAINT, or right paren")
 		}
 	}
@@ -1217,6 +1216,9 @@ func (p *Parser) parseIdent(desc string) (*Ident, error) {
 	case IDENT, QIDENT:
 		return &Ident{Name: lit, NamePos: pos, Quoted: tok == QIDENT}, nil
 	default:
+		if isBareToken(tok) {
+			return &Ident{Name: lit, NamePos: pos}, nil
+		}
 		return nil, p.errorExpected(pos, tok, desc)
 	}
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -254,6 +254,23 @@ func TestParser_ParseStatement(t *testing.T) {
 			Rparen: pos(28),
 		})
 
+		// Column name as a bare keyword
+		AssertParseStatement(t, `CREATE TABLE tbl (key)`, &sql.CreateTableStatement{
+			Create: pos(0),
+			Table:  pos(7),
+			Name: &sql.Ident{
+				Name:    "tbl",
+				NamePos: pos(13),
+			},
+			Lparen: pos(17),
+			Columns: []*sql.ColumnDefinition{
+				{
+					Name: &sql.Ident{NamePos: pos(18), Name: "key"},
+				},
+			},
+			Rparen: pos(21),
+		})
+
 		// With comments
 		AssertParseStatement(t, "CREATE TABLE tbl ( -- comment\n\tcol1 TEXT, -- comment\n\t  col2 TEXT)", &sql.CreateTableStatement{
 			Create: pos(0),

--- a/token.go
+++ b/token.go
@@ -6,16 +6,22 @@ import (
 	"strings"
 )
 
-var keywords map[string]Token
+var (
+	keywords      = make(map[string]Token)
+	bareTokensMap = make(map[Token]struct{})
+)
 
 func init() {
-	keywords = make(map[string]Token)
 	for i := keyword_beg + 1; i < keyword_end; i++ {
 		keywords[tokens[i]] = i
 	}
 	keywords[tokens[NULL]] = NULL
 	keywords[tokens[TRUE]] = TRUE
 	keywords[tokens[FALSE]] = FALSE
+
+	for _, tok := range bareTokens {
+		bareTokensMap[tok] = struct{}{}
+	}
 }
 
 // Token is the set of lexical tokens of the Go programming language.
@@ -451,6 +457,20 @@ var tokens = [...]string{
 	WITHOUT:           "WITHOUT",
 }
 
+// A list of keywords that can be used as unquoted identifiers.
+var bareTokens = [...]Token{
+	ABORT, ACTION, AFTER, ALWAYS, ANALYZE, ASC, ATTACH, BEFORE, BEGIN, BY,
+	CASCADE, CAST, COLUMN, CONFLICT, CROSS, CURRENT, CURRENT_DATE,
+	CURRENT_TIME, CURRENT_TIMESTAMP, DATABASE, DEFERRED, DESC, DETACH, DO,
+	EACH, END, EXCLUDE, EXCLUSIVE, EXPLAIN, FAIL, FILTER, FIRST, FOLLOWING,
+	FOR, GENERATED, GLOB, GROUPS, IF, IGNORE, IMMEDIATE, INDEXED, INITIALLY,
+	INNER, INSTEAD, KEY, LAST, LEFT, LIKE, MATCH, NATURAL, NO, NULLS, OF,
+	OFFSET, OTHERS, OUTER, OVER, PARTITION, PLAN, PRAGMA, PRECEDING, QUERY,
+	RAISE, RANGE, RECURSIVE, REGEXP, REINDEX, RELEASE, RENAME, REPLACE,
+	RESTRICT, ROLLBACK, ROW, ROWS, SAVEPOINT, TEMP, TIES, TRIGGER,
+	UNBOUNDED, VACUUM, VIEW, VIRTUAL, WINDOW, WITH, WITHOUT,
+}
+
 func (tok Token) String() string {
 	s := ""
 	if 0 <= tok && tok < Token(len(tokens)) {
@@ -467,6 +487,12 @@ func Lookup(ident string) Token {
 		return tok
 	}
 	return IDENT
+}
+
+// isBareToken returns true if keyword token can be used as an identifier.
+func isBareToken(tok Token) bool {
+	_, ok := bareTokensMap[tok]
+	return ok
 }
 
 func (tok Token) IsLiteral() bool {


### PR DESCRIPTION
For some reason, SQLite allows a subset of the [keyword list](https://sqlite.org/lang_keywords.html) to be used as identifiers without wrapping double quotes.

Fixes https://github.com/rqlite/sql/issues/29