### PR TITLE
Return an error if a data type isn't detected in a column definition

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -382,6 +382,8 @@ func (p *Parser) parseColumnDefinition() (_ *ColumnDefinition, err error) {
 		if col.Type, err = p.parseType(); err != nil {
 			return &col, err
 		}
+	} else {
+		 return nil, p.errorExpected(p.pos, p.tok, "data type")
 	}
 
 	if col.Constraints, err = p.parseColumnConstraints(); err != nil {

--- a/parser.go
+++ b/parser.go
@@ -383,7 +383,7 @@ func (p *Parser) parseColumnDefinition() (_ *ColumnDefinition, err error) {
 			return &col, err
 		}
 	} else {
-		 return nil, p.errorExpected(p.pos, p.tok, "data type")
+		return nil, p.errorExpected(p.pos, p.tok, "data type")
 	}
 
 	if col.Constraints, err = p.parseColumnConstraints(); err != nil {

--- a/parser_test.go
+++ b/parser_test.go
@@ -235,7 +235,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		})
 
 		// No column type
-		AssertParseStatement(t, `CREATE TABLE tbl (col1, col2)`, &sql.CreateTableStatement{
+		AssertParseStatement(t, `CREATE TABLE tbl (col1 INT, col2 INT)`, &sql.CreateTableStatement{
 			Create: pos(0),
 			Table:  pos(7),
 			Name: &sql.Ident{
@@ -246,16 +246,18 @@ func TestParser_ParseStatement(t *testing.T) {
 			Columns: []*sql.ColumnDefinition{
 				{
 					Name: &sql.Ident{NamePos: pos(18), Name: "col1"},
+					Type: &sql.Type{Name: &sql.Ident{NamePos: pos(23), Name: "INT"}},
 				},
 				{
-					Name: &sql.Ident{NamePos: pos(24), Name: "col2"},
+					Name: &sql.Ident{NamePos: pos(28), Name: "col2"},
+					Type: &sql.Type{Name: &sql.Ident{NamePos: pos(33), Name: "INT"}},
 				},
 			},
-			Rparen: pos(28),
+			Rparen: pos(36),
 		})
 
 		// Column name as a bare keyword
-		AssertParseStatement(t, `CREATE TABLE tbl (key)`, &sql.CreateTableStatement{
+		AssertParseStatement(t, `CREATE TABLE tbl (key TEXT)`, &sql.CreateTableStatement{
 			Create: pos(0),
 			Table:  pos(7),
 			Name: &sql.Ident{
@@ -266,9 +268,10 @@ func TestParser_ParseStatement(t *testing.T) {
 			Columns: []*sql.ColumnDefinition{
 				{
 					Name: &sql.Ident{NamePos: pos(18), Name: "key"},
+					Type: &sql.Type{Name: &sql.Ident{NamePos: pos(22), Name: "TEXT"}},
 				},
 			},
-			Rparen: pos(21),
+			Rparen: pos(26),
 		})
 
 		// With comments
@@ -441,7 +444,7 @@ func TestParser_ParseStatement(t *testing.T) {
 
 		AssertParseStatementError(t, `CREATE TABLE IF`, `1:15: expected NOT, found 'EOF'`)
 		AssertParseStatementError(t, `CREATE TABLE IF NOT`, `1:19: expected EXISTS, found 'EOF'`)
-		AssertParseStatementError(t, `CREATE TABLE tbl (col1`, `1:22: expected column name, CONSTRAINT, or right paren, found 'EOF'`)
+		AssertParseStatementError(t, `CREATE TABLE tbl (col1`, `1:22: expected data type, found 'EOF'`)
 		AssertParseStatementError(t, `CREATE TABLE tbl (col1 DECIMAL(`, `1:31: expected precision, found 'EOF'`)
 		AssertParseStatementError(t, `CREATE TABLE tbl (col1 DECIMAL(-12,`, `1:35: expected scale, found 'EOF'`)
 		AssertParseStatementError(t, `CREATE TABLE tbl (col1 DECIMAL(1,2`, `1:34: expected right paren, found 'EOF'`)


### PR DESCRIPTION
I accidentally wrote `NOT_NULL` in my input to this library instead of `NOT NULL`, and upon using the `String()` method to render the AST into an SQL string, I got a segfault. I tracked it down to the following if statement:

https://github.com/rqlite/sql/blob/bbf5a343156d74271f90687f12c64c315dee6a2c/parser.go#L381-L385

Since `NOT_NULL` is not a data type or constraint, it's interpreted by the parser as a column name. Due to the above if statement, `col.Type` is never set on that supposed column definition. Later, this line attempts to call the String method on the nil type, which is what causes the panic:

https://github.com/rqlite/sql/blob/123a320627bfe1e84f653c01329e1b7ca3384c5f/ast.go#L726

As far as I know, the SQL standard requires that all columns have a data type, so this PR returns an error if a column definition doesn't have a data type.