### PR TITLE
Fix panic when String() is called on a column definition with no data type

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -722,8 +722,10 @@ func cloneColumnDefinitions(a []*ColumnDefinition) []*ColumnDefinition {
 func (c *ColumnDefinition) String() string {
 	var buf bytes.Buffer
 	buf.WriteString(c.Name.String())
-	buf.WriteString(" ")
-	buf.WriteString(c.Type.String())
+	if c.Type != nil {
+		buf.WriteString(" ")
+		buf.WriteString(c.Type.String())
+	}
 	for i := range c.Constraints {
 		buf.WriteString(" ")
 		buf.WriteString(c.Constraints[i].String())

--- a/ast_test.go
+++ b/ast_test.go
@@ -126,8 +126,11 @@ func TestCreateTableStatement_String(t *testing.T) {
 				Name: &sql.Ident{Name: "baz"},
 				Type: &sql.Type{Name: &sql.Ident{Name: "TEXT"}},
 			},
+			{
+				Name: &sql.Ident{Name: "no_type"},
+			},
 		},
-	}, `CREATE TABLE IF NOT EXISTS "foo" ("bar" INTEGER, "baz" TEXT)`)
+	}, `CREATE TABLE IF NOT EXISTS "foo" ("bar" INTEGER, "baz" TEXT, "no_type")`)
 
 	AssertStatementStringer(t, &sql.CreateTableStatement{
 		Name: &sql.Ident{Name: "foo"},


### PR DESCRIPTION
Calling the `String()` method on a column definition with no data type currently causes a panic due to this attempt to call `String()` on a `Type` field that could potentially be `nil`:

https://github.com/rqlite/sql/blob/123a320627bfe1e84f653c01329e1b7ca3384c5f/ast.go#L726

This PR checks to make sure the `Type` field isn't nil before calling `String()` and modifies the tests to ensure that a nil `Type` doesn't cause a panic.

Replaces #36