### PR TITLE
Fix parsing of qualified references starting with `e` as a decimal with an exponent

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -2202,6 +2202,42 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		})
 
+		AssertParseStatement(t, `SELECT * FROM foo WHERE foo.elem = 0`, &sql.SelectStatement{
+			Select: pos(0),
+			Columns: []*sql.ResultColumn{
+				{
+					Star: pos(7),
+				},
+			},
+			From: pos(9),
+			Source: &sql.QualifiedTableName{
+				Name: &sql.Ident{
+					NamePos: pos(14),
+					Name:    "foo",
+				},
+			},
+			Where: pos(18),
+			WhereExpr: &sql.BinaryExpr{
+				X: &sql.QualifiedRef{
+					Table: &sql.Ident{
+						NamePos: pos(24),
+						Name:    "foo",
+					},
+					Dot: pos(27),
+					Column: &sql.Ident{
+						NamePos: pos(28),
+						Name:    "elem",
+					},
+				},
+				OpPos: pos(33),
+				Op:    sql.EQ,
+				Y: &sql.NumberLit{
+					ValuePos: pos(35),
+					Value:    "0",
+				},
+			},
+		})
+
 		AssertParseStatementError(t, `WITH `, `1:5: expected table name, found 'EOF'`)
 		AssertParseStatementError(t, `WITH cte`, `1:8: expected AS, found 'EOF'`)
 		AssertParseStatementError(t, `WITH cte (`, `1:10: expected column name, found 'EOF'`)

--- a/scanner.go
+++ b/scanner.go
@@ -292,6 +292,12 @@ func (s *Scanner) scanNumber() (Pos, Token, string) {
 		}
 	}
 
+	// If we just have a dot in the buffer with no digits by this point,
+	// this can't be a number, so we can stop and return DOT
+	if s.buf.String() == "." {
+		return pos, DOT, "."
+	}
+
 	// Read exponent with optional +/- sign.
 	if ch := s.peek(); ch == 'e' || ch == 'E' {
 		tok = FLOAT
@@ -319,11 +325,7 @@ func (s *Scanner) scanNumber() (Pos, Token, string) {
 		}
 	}
 
-	lit := s.buf.String()
-	if lit == "." {
-		return pos, DOT, lit
-	}
-	return pos, tok, lit
+	return pos, tok, s.buf.String()
 }
 
 func (s *Scanner) read() (rune, Pos) {

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -91,6 +91,7 @@ func TestScanner_Scan(t *testing.T) {
 		AssertScan(t, `123.E45`, sql.FLOAT, `123.E45`)
 		AssertScan(t, `123E+4`, sql.FLOAT, `123E+4`)
 		AssertScan(t, `123E-4`, sql.FLOAT, `123E-4`)
+		AssertScan(t, `.0E-2`, sql.FLOAT, `.0E-2`)
 		AssertScan(t, `123E`, sql.ILLEGAL, `123E`)
 		AssertScan(t, `123E+`, sql.ILLEGAL, `123E+`)
 		AssertScan(t, `123E-`, sql.ILLEGAL, `123E-`)

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -95,7 +95,6 @@ func TestScanner_Scan(t *testing.T) {
 		AssertScan(t, `123E`, sql.ILLEGAL, `123E`)
 		AssertScan(t, `123E+`, sql.ILLEGAL, `123E+`)
 		AssertScan(t, `123E-`, sql.ILLEGAL, `123E-`)
-		AssertScan(t, `.E2`, sql.DOT, `.`)
 	})
 	t.Run("BIND", func(t *testing.T) {
 		AssertScan(t, `?'`, sql.BIND, `?`)
@@ -176,6 +175,7 @@ func TestScanner_Scan(t *testing.T) {
 	})
 	t.Run("DOT", func(t *testing.T) {
 		AssertScan(t, ".", sql.DOT, ".")
+		AssertScan(t, `.E2`, sql.DOT, `.`)
 	})
 	t.Run("JSON_EXTRACT_JSON", func(t *testing.T) {
 		AssertScan(t, "->", sql.JSON_EXTRACT_JSON, "->")

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -95,6 +95,7 @@ func TestScanner_Scan(t *testing.T) {
 		AssertScan(t, `123E`, sql.ILLEGAL, `123E`)
 		AssertScan(t, `123E+`, sql.ILLEGAL, `123E+`)
 		AssertScan(t, `123E-`, sql.ILLEGAL, `123E-`)
+		AssertScan(t, `.E2`, sql.DOT, `.`)
 	})
 	t.Run("BIND", func(t *testing.T) {
 		AssertScan(t, `?'`, sql.BIND, `?`)


### PR DESCRIPTION
Currently, parsing the following valid SQLite `SELECT` statement yields an error:

```sql
SELECT * FROM foo WHERE foo.elem = 0;
```

This is happening because `scanNumber` is detecting the `e` in elem as part of an exponent in a float literal:

https://github.com/rqlite/sql/blob/768acfbd137ea63346566df98bc2dc16d9f049fd/scanner.go#L296

According to the SQLite [numeric-literal](https://sqlite.org/syntax/numeric-literal.html) parsing diagram, exponents must have digits in front of them, meaning `0e1`, `0.0e1`, `0.e1`, and `.0e1` are all supported, but `.e1` is not. The current scanner sees `.e1` as a valid float, which it isn't.

This PR modifies the scanner to return `DOT` if no digits are found before an exponent, which makes qualified references parse correctly. It also adds tests to make sure that they're parsed properly and that supported forms of exponents are still scanned correctly.