### PR TITLE
 Add support for `SELECT` statements in expressions 

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -215,6 +215,7 @@ func (*Range) expr()        {}
 func (*StringLit) expr()    {}
 func (*TimestampLit) expr() {}
 func (*UnaryExpr) expr()    {}
+func (SelectExpr) expr()    {}
 
 // CloneExpr returns a deep copy expr.
 func CloneExpr(expr Expr) Expr {
@@ -3487,6 +3488,16 @@ func (expr *ParenExpr) Clone() *ParenExpr {
 // String returns the string representation of the expression.
 func (expr *ParenExpr) String() string {
 	return fmt.Sprintf("(%s)", expr.X.String())
+}
+
+// SelectExpr represents a SELECT statement inside an expression.
+type SelectExpr struct {
+	*SelectStatement
+}
+
+// Clone returns a deep copy of expr.
+func (expr SelectExpr) Clone() SelectExpr {
+	return SelectExpr{expr.SelectStatement.Clone()}
 }
 
 type Window struct {

--- a/parser.go
+++ b/parser.go
@@ -2322,6 +2322,10 @@ func (p *Parser) parseOperand() (expr Expr, err error) {
 	case EXISTS:
 		p.unscan()
 		return p.parseExists(Pos{})
+	case SELECT:
+		p.unscan()
+		selectStmt, err := p.parseSelectStatement(false, nil)
+		return SelectExpr{selectStmt}, err
 	default:
 		return nil, p.errorExpected(p.pos, p.tok, "expression")
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -3187,6 +3187,45 @@ func TestParser_ParseStatement(t *testing.T) {
 			OffsetExpr:  &sql.NumberLit{ValuePos: pos(25), Value: "2"},
 		})
 
+		AssertParseStatement(t, `DELETE FROM tbl1 WHERE id IN (SELECT tbl1_id FROM tbl2 WHERE foo = 'bar')`, &sql.DeleteStatement{
+			Delete: pos(0),
+			From:   pos(7),
+			Table: &sql.QualifiedTableName{
+				Name: &sql.Ident{NamePos: pos(12), Name: "tbl1"},
+			},
+			Where: pos(17),
+			WhereExpr: &sql.BinaryExpr{
+				X:     &sql.Ident{NamePos: pos(23), Name: "id"},
+				OpPos: pos(26),
+				Op:    sql.IN,
+				Y: &sql.ExprList{
+					Lparen: pos(29),
+					Exprs: []sql.Expr{sql.SelectExpr{
+						SelectStatement: &sql.SelectStatement{
+							Select: pos(30),
+							Columns: []*sql.ResultColumn{
+								{
+									Expr: &sql.Ident{NamePos: pos(37), Name: "tbl1_id"},
+								},
+							},
+							From: pos(45),
+							Source: &sql.QualifiedTableName{
+								Name: &sql.Ident{NamePos: pos(50), Name: "tbl2"},
+							},
+							Where: pos(55),
+							WhereExpr: &sql.BinaryExpr{
+								X:     &sql.Ident{NamePos: pos(61), Name: "foo"},
+								OpPos: pos(65),
+								Op:    sql.EQ,
+								Y:     &sql.StringLit{ValuePos: pos(67), Value: "bar"},
+							},
+						},
+					}},
+					Rparen: pos(72),
+				},
+			},
+		})
+
 		AssertParseStatementError(t, `DELETE`, `1:6: expected FROM, found 'EOF'`)
 		AssertParseStatementError(t, `DELETE FROM`, `1:11: expected table name, found 'EOF'`)
 		AssertParseStatementError(t, `DELETE FROM tbl WHERE`, `1:21: expected expression, found 'EOF'`)


### PR DESCRIPTION
According to SQLite's [expr](https://www.sqlite.org/syntax/expr.html) parsing diagram, `SELECT` statements can be used in expressions in some cases, such as:

```sql
DELETE FROM tbl1 WHERE id IN (SELECT tbl1_id FROM tbl2 WHERE foo = 'bar')
```

Currently, the parser doesn't support this valid SQLite statement and returns an error.

This PR adds support for `SELECT` statements within expressions and adds tests to make sure they're parsed properly.

Fixes #8 