### PR TITLE
 Fix parsing of unknown types and types with multiple identifiers 

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1236,7 +1236,7 @@ func (p *Parser) parseType() (_ *Type, err error) {
 			typ.Name.Name += " " + typeName.Name
 		}
 	}
-	
+
 	if typ.Name == nil {
 		return &typ, p.errorExpected(p.pos, p.tok, "type name")
 	}

--- a/parser.go
+++ b/parser.go
@@ -378,7 +378,7 @@ func (p *Parser) parseColumnDefinition() (_ *ColumnDefinition, err error) {
 		return &col, err
 	}
 
-	if _, tok, lit := p.peekScan(); tok == IDENT && isTypeName(lit) {
+	if tok := p.peek(); tok == IDENT {
 		if col.Type, err = p.parseType(); err != nil {
 			return &col, err
 		}
@@ -1225,8 +1225,20 @@ func (p *Parser) parseIdent(desc string) (*Ident, error) {
 
 func (p *Parser) parseType() (_ *Type, err error) {
 	var typ Type
-	if typ.Name, err = p.parseIdent("type name"); err != nil {
-		return &typ, err
+	for p.peek() == IDENT {
+		typeName, err := p.parseIdent("type name")
+		if err != nil {
+			return &typ, err
+		}
+		if typ.Name == nil {
+			typ.Name = typeName
+		} else {
+			typ.Name.Name += " " + typeName.Name
+		}
+	}
+	
+	if typ.Name == nil {
+		return &typ, p.errorExpected(p.pos, p.tok, "type name")
 	}
 
 	// Optionally parse precision & scale.

--- a/parser_test.go
+++ b/parser_test.go
@@ -439,6 +439,55 @@ func TestParser_ParseStatement(t *testing.T) {
 			Rparen: pos(66),
 		})
 
+		AssertParseStatement(t, "CREATE TABLE t (c1 CHARACTER VARYING, c2 UUID, c3 TIMESTAMP)", &sql.CreateTableStatement{
+			Create: pos(0),
+			Table: pos(7),
+			Name: &sql.Ident{
+				NamePos: pos(13),
+				Name: "t",
+			},
+			Lparen: pos(15),
+			Columns: []*sql.ColumnDefinition{
+				{
+					Name: &sql.Ident{
+						NamePos: pos(16),
+						Name: "c1",
+					},
+					Type: &sql.Type{
+						Name: &sql.Ident{
+							NamePos: pos(19),
+							Name: "CHARACTER VARYING",
+						},
+					},
+				},
+				{
+					Name: &sql.Ident{
+						NamePos: pos(38),
+						Name: "c2",
+					},
+					Type: &sql.Type{
+						Name: &sql.Ident{
+							NamePos: pos(41),
+							Name: "UUID",
+						},
+					},
+				},
+				{
+					Name: &sql.Ident{
+						NamePos: pos(47),
+						Name: "c3",
+					},
+					Type: &sql.Type{
+						Name: &sql.Ident{
+							NamePos: pos(50),
+							Name: "TIMESTAMP",
+						},
+					},
+				},
+			},
+			Rparen: pos(59),
+		})
+
 		AssertParseStatementError(t, `CREATE TABLE IF`, `1:15: expected NOT, found 'EOF'`)
 		AssertParseStatementError(t, `CREATE TABLE IF NOT`, `1:19: expected EXISTS, found 'EOF'`)
 		AssertParseStatementError(t, `CREATE TABLE tbl (col1`, `1:22: expected column name, CONSTRAINT, or right paren, found 'EOF'`)
@@ -3985,6 +4034,16 @@ func TestParser_ParseExpr(t *testing.T) {
 			Type:   &sql.Type{Name: &sql.Ident{NamePos: pos(11), Name: "INTEGER"}},
 			Rparen: pos(18),
 		})
+		
+		AssertParseExpr(t, `CAST (20 AS SOME TYPE)`, &sql.CastExpr{
+			Cast:   pos(0),
+			Lparen: pos(5),
+			X:      &sql.NumberLit{ValuePos: pos(6), Value: "20"},
+			As:     pos(9),
+			Type:   &sql.Type{Name: &sql.Ident{NamePos: pos(12), Name: "SOME TYPE"}},
+			Rparen: pos(21),
+		})
+		
 		AssertParseExprError(t, `CAST`, `1:4: expected left paren, found 'EOF'`)
 		AssertParseExprError(t, `CAST (`, `1:6: expected expression, found 'EOF'`)
 		AssertParseExprError(t, `CAST (1`, `1:7: expected AS, found 'EOF'`)

--- a/parser_test.go
+++ b/parser_test.go
@@ -441,46 +441,46 @@ func TestParser_ParseStatement(t *testing.T) {
 
 		AssertParseStatement(t, "CREATE TABLE t (c1 CHARACTER VARYING, c2 UUID, c3 TIMESTAMP)", &sql.CreateTableStatement{
 			Create: pos(0),
-			Table: pos(7),
+			Table:  pos(7),
 			Name: &sql.Ident{
 				NamePos: pos(13),
-				Name: "t",
+				Name:    "t",
 			},
 			Lparen: pos(15),
 			Columns: []*sql.ColumnDefinition{
 				{
 					Name: &sql.Ident{
 						NamePos: pos(16),
-						Name: "c1",
+						Name:    "c1",
 					},
 					Type: &sql.Type{
 						Name: &sql.Ident{
 							NamePos: pos(19),
-							Name: "CHARACTER VARYING",
+							Name:    "CHARACTER VARYING",
 						},
 					},
 				},
 				{
 					Name: &sql.Ident{
 						NamePos: pos(38),
-						Name: "c2",
+						Name:    "c2",
 					},
 					Type: &sql.Type{
 						Name: &sql.Ident{
 							NamePos: pos(41),
-							Name: "UUID",
+							Name:    "UUID",
 						},
 					},
 				},
 				{
 					Name: &sql.Ident{
 						NamePos: pos(47),
-						Name: "c3",
+						Name:    "c3",
 					},
 					Type: &sql.Type{
 						Name: &sql.Ident{
 							NamePos: pos(50),
-							Name: "TIMESTAMP",
+							Name:    "TIMESTAMP",
 						},
 					},
 				},
@@ -4034,7 +4034,7 @@ func TestParser_ParseExpr(t *testing.T) {
 			Type:   &sql.Type{Name: &sql.Ident{NamePos: pos(11), Name: "INTEGER"}},
 			Rparen: pos(18),
 		})
-		
+
 		AssertParseExpr(t, `CAST (20 AS SOME TYPE)`, &sql.CastExpr{
 			Cast:   pos(0),
 			Lparen: pos(5),
@@ -4043,7 +4043,7 @@ func TestParser_ParseExpr(t *testing.T) {
 			Type:   &sql.Type{Name: &sql.Ident{NamePos: pos(12), Name: "SOME TYPE"}},
 			Rparen: pos(21),
 		})
-		
+
 		AssertParseExprError(t, `CAST`, `1:4: expected left paren, found 'EOF'`)
 		AssertParseExprError(t, `CAST (`, `1:6: expected expression, found 'EOF'`)
 		AssertParseExprError(t, `CAST (1`, `1:7: expected AS, found 'EOF'`)


### PR DESCRIPTION
SQLite allows the use of any string as a type. It also allows having multiple identifiers in types, as can be seen in this test I ran:

```
sqlite> .headers on
sqlite> CREATE TABLE tbl2 (field X Y Z NOT NULL);
sqlite> PRAGMA table_info(tbl2);
cid|name|type|notnull|dflt_value|pk
0|field|X Y Z|1||0
```

Currently, the parser can handle unknown types in `CAST` expressions, but not `CREATE TABLE` statements, because of the `isTypeName` condition here:

https://github.com/rqlite/sql/blob/c33fce571d190277ddf2aa763240a3462699a588/parser.go#L381

This PR removes that condition, and modifies the parser so that it can parse types with multiple identifiers. It also adds tests to make sure that these changes work properly.

Fixes #33