### PR TITLE
Fix bug in parser when parsing unary source (VALUES ...)

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -2022,6 +2022,8 @@ func (p *Parser) parseUnarySource() (source Source, err error) {
 		return p.parseParenSource()
 	case IDENT, QIDENT:
 		return p.parseQualifiedTable()
+	case VALUES:
+		return p.parseSelectStatement(false, nil)
 	default:
 		return nil, p.errorExpected(p.pos, p.tok, "table name or left paren")
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -1872,6 +1872,30 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		})
 
+		AssertParseStatement(t, `SELECT * FROM (VALUES (NULL))`, &sql.SelectStatement{
+			Select: pos(0),
+			Columns: []*sql.ResultColumn{
+				{Star: pos(7)},
+			},
+			From: pos(9),
+			Source: &sql.ParenSource{
+				Lparen: pos(14),
+				X: &sql.SelectStatement{
+					Values: pos(15),
+					ValueLists: []*sql.ExprList{
+						{
+							Lparen: pos(22),
+							Exprs: []sql.Expr{
+								&sql.NullLit{Pos: pos(23)},
+							},
+							Rparen: pos(27),
+						},
+					},
+				},
+				Rparen: pos(28),
+			},
+		})
+
 		AssertParseStatement(t, `SELECT * FROM foo, bar`, &sql.SelectStatement{
 			Select: pos(0),
 			Columns: []*sql.ResultColumn{


### PR DESCRIPTION
The parser was unable to parse 
```sql
SELECT * FROM (VALUES (NULL));
``` 
but this is valid sqlite syntax.

The issue was resolved in `parseUnarySource` by adding the switch case `VALUES`. I also added a unit test 