### PR TITLE
Fix bug with replace() core function

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -1743,6 +1743,31 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		})
 
+		AssertParseStatement(t, `SELECT replace(c0, 'a', 1) FROM t;`, &sql.SelectStatement{
+			Select: pos(0),
+			Columns: []*sql.ResultColumn{
+				{
+					Expr: &sql.Call{
+						Name:   &sql.Ident{NamePos: pos(7), Name: "replace"},
+						Lparen: pos(14),
+						Args: []sql.Expr{
+							&sql.Ident{NamePos: pos(15), Name: "c0"},
+							&sql.StringLit{ValuePos: pos(19), Value: "a"},
+							&sql.NumberLit{ValuePos: pos(24), Value: "1"},
+						},
+						Rparen: pos(25),
+					},
+				},
+			},
+			From: pos(27),
+			Source: &sql.QualifiedTableName{
+				Name: &sql.Ident{
+					NamePos: pos(32),
+					Name:    "t",
+				},
+			},
+		})
+
 		AssertParseStatement(t, `SELECT * FROM tbl`, &sql.SelectStatement{
 			Select: pos(0),
 			Columns: []*sql.ResultColumn{
@@ -2710,6 +2735,7 @@ func TestParser_ParseStatement(t *testing.T) {
 				},
 			},
 		})
+
 		AssertParseStatement(t, `INSERT OR REPLACE INTO tbl (x) VALUES (1)`, &sql.InsertStatement{
 			Insert:          pos(0),
 			InsertOr:        pos(7),

--- a/token.go
+++ b/token.go
@@ -524,6 +524,9 @@ func isExprIdentToken(tok Token) bool {
 	// List keywords that can be used as identifiers in expressions
 	case ROWID, CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP:
 		return true
+	// replace() core function
+	case REPLACE:
+		return true
 	// Add any other non-reserved keywords here
 	default:
 		return false


### PR DESCRIPTION
SQLite docs: https://www.sqlite.org/lang_corefunc.html

The issue was that the identifier `replace` in core function call  `replace()` was being tokenized as `REPLACE` but it can also be used as a function. To solve this, I added REPLACE token as valid identifier in expression (`isExprIdentToken`) with a unit test