### PR TITLE
Add collation clause to ORDER BY

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -1989,8 +1989,36 @@ func (c *OverClause) String() string {
 	return fmt.Sprintf("OVER %s", c.Definition.String())
 }
 
+type CollationClause struct {
+	Collate Pos    // position of COLLATE keyword
+	Name    *Ident // collation function (e.g. BINARY, NOCASE, RTRIM or custom)
+
+}
+
+// Clone returns a deep copy of c.
+func (c *CollationClause) Clone() *CollationClause {
+	if c == nil {
+		return nil
+	}
+	other := *c
+	other.Name = c.Name.Clone()
+	return &other
+}
+
+// String returns the string representation of the collation.
+func (c *CollationClause) String() string {
+	var buf bytes.Buffer
+
+	buf.WriteString("COLLATE ")
+	buf.WriteString(c.Name.String())
+
+	return buf.String()
+}
+
 type OrderingTerm struct {
 	X Expr // ordering expression
+
+	Collation *CollationClause
 
 	Asc  Pos // position of ASC keyword
 	Desc Pos // position of DESC keyword
@@ -2026,6 +2054,10 @@ func (t *OrderingTerm) String() string {
 	var buf bytes.Buffer
 	buf.WriteString(t.X.String())
 
+	if t.Collation != nil {
+		buf.WriteString(" ")
+		buf.WriteString(t.Collation.String())
+	}
 	if t.Asc.IsValid() {
 		buf.WriteString(" ASC")
 	} else if t.Desc.IsValid() {

--- a/parser.go
+++ b/parser.go
@@ -2670,6 +2670,13 @@ func (p *Parser) parseOrderingTerm() (_ *OrderingTerm, err error) {
 		return &term, err
 	}
 
+	// Parse optional "COLLATE"
+	if p.peek() == COLLATE {
+		if term.Collation, err = p.parseCollationClause(); err != nil {
+			return &term, err
+		}
+	}
+
 	// Parse optional sort direction ("ASC" or "DESC")
 	switch p.peek() {
 	case ASC:
@@ -2692,6 +2699,19 @@ func (p *Parser) parseOrderingTerm() (_ *OrderingTerm, err error) {
 	}
 
 	return &term, nil
+}
+
+func (p *Parser) parseCollationClause() (_ *CollationClause, err error) {
+	assert(p.peek() == COLLATE)
+
+	var clause CollationClause
+	clause.Collate, _, _ = p.scan()
+
+	if clause.Name, err = p.parseIdent("collation name"); err != nil {
+		return &clause, err
+	}
+
+	return &clause, nil
 }
 
 func (p *Parser) parseFrameSpec() (_ *FrameSpec, err error) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -2177,6 +2177,42 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		})
 
+		AssertParseStatement(t, `SELECT * ORDER BY c1 COLLATE BINARY;`, &sql.SelectStatement{
+			Select: pos(0),
+			Columns: []*sql.ResultColumn{
+				{Star: pos(7)},
+			},
+			Order:   pos(9),
+			OrderBy: pos(15),
+			OrderingTerms: []*sql.OrderingTerm{
+				{
+					X: &sql.Ident{NamePos: pos(18), Name: "c1"},
+					Collation: &sql.CollationClause{
+						Collate: pos(21),
+						Name:    &sql.Ident{NamePos: pos(29), Name: "BINARY"},
+					},
+				},
+			},
+		})
+
+		AssertParseStatement(t, `SELECT * ORDER BY c1 COLLATE NOCASE DESC;`, &sql.SelectStatement{
+			Select: pos(0),
+			Columns: []*sql.ResultColumn{
+				{Star: pos(7)},
+			},
+			Order:   pos(9),
+			OrderBy: pos(15),
+			OrderingTerms: []*sql.OrderingTerm{
+				{
+					X: &sql.Ident{NamePos: pos(18), Name: "c1"},
+					Collation: &sql.CollationClause{
+						Collate: pos(21), Name: &sql.Ident{NamePos: pos(29), Name: "NOCASE"},
+					},
+					Desc: pos(36),
+				},
+			},
+		})
+
 		AssertParseStatement(t, `SELECT * LIMIT 1`, &sql.SelectStatement{
 			Select: pos(0),
 			Columns: []*sql.ResultColumn{


### PR DESCRIPTION
I have added the `COLLATION` keyword to `ORDER BY` as per [spec](https://sqlite.org/syntax/ordering-term.html):
```sql
SELECT * ORDER BY c1 COLLATE NOCASE DESC;
```
 I saw there is a struct called `CollationConstraint` but it seems to be highly coupled with parsing tables and columns so i have left it alone.
