### PR TITLE
Added parsing schema in parseQualifiedTableName

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -3156,6 +3156,8 @@ func (c *ResultColumn) String() string {
 }
 
 type QualifiedTableName struct {
+	Schema     *Ident // schema name
+	Dot        Pos    // position of dot
 	Name       *Ident // table name
 	As         Pos    // position of AS keyword
 	Alias      *Ident // optional table alias
@@ -3181,6 +3183,7 @@ func (n *QualifiedTableName) Clone() *QualifiedTableName {
 		return nil
 	}
 	other := *n
+	other.Schema = n.Schema.Clone()
 	other.Name = n.Name.Clone()
 	other.Alias = n.Alias.Clone()
 	other.Index = n.Index.Clone()
@@ -3190,6 +3193,10 @@ func (n *QualifiedTableName) Clone() *QualifiedTableName {
 // String returns the string representation of the table name.
 func (n *QualifiedTableName) String() string {
 	var buf bytes.Buffer
+	if n.Schema != nil {
+		buf.WriteString(n.Schema.String())
+		buf.WriteString(".")
+	}
 	buf.WriteString(n.Name.String())
 	if n.Alias != nil {
 		fmt.Fprintf(&buf, " AS %s", n.Alias.String())

--- a/parser.go
+++ b/parser.go
@@ -2163,7 +2163,17 @@ func (p *Parser) parseQualifiedTable() (_ Source, err error) {
 
 func (p *Parser) parseQualifiedTableName(ident *Ident) (_ *QualifiedTableName, err error) {
 	var tbl QualifiedTableName
-	tbl.Name = ident
+
+	if tok := p.peek(); tok == DOT {
+		tbl.Schema = ident
+		tbl.Dot, _, _ = p.scan()
+
+		if tbl.Name, err = p.parseIdent("table name"); err != nil {
+			return &tbl, err
+		}
+	} else {
+		tbl.Name = ident
+	}
 
 	// Parse optional table alias ("AS alias" or just "alias").
 	if tok := p.peek(); tok == AS || isIdentToken(tok) {
@@ -2174,7 +2184,6 @@ func (p *Parser) parseQualifiedTableName(ident *Ident) (_ *QualifiedTableName, e
 			return &tbl, err
 		}
 	}
-
 	// Parse optional "INDEXED BY index-name" or "NOT INDEXED".
 	switch p.peek() {
 	case INDEXED:

--- a/parser_test.go
+++ b/parser_test.go
@@ -1779,6 +1779,19 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		})
 
+		AssertParseStatement(t, `SELECT * FROM main.tbl;`, &sql.SelectStatement{
+			Select: pos(0),
+			Columns: []*sql.ResultColumn{
+				{Star: pos(7)},
+			},
+			From: pos(9),
+			Source: &sql.QualifiedTableName{
+				Schema: &sql.Ident{NamePos: pos(14), Name: "main"},
+				Dot:    pos(18),
+				Name:   &sql.Ident{NamePos: pos(19), Name: "tbl"},
+			},
+		})
+
 		AssertParseStatement(t, `SELECT DISTINCT * FROM tbl`, &sql.SelectStatement{
 			Select:   pos(0),
 			Distinct: pos(7),


### PR DESCRIPTION
For example queries in the form:
```sql
SELECT * FROM <schema>.<table>
```
can now be parsed, as per [spec](https://sqlite.org/syntax/table-or-subquery.html).

Note: this does not add support for parsing table function names with expressions