### PR TITLE
Fixed alias using only parentheses

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -2140,7 +2140,7 @@ func (p *Parser) parseParenSource() (_ *ParenSource, err error) {
 	source.Rparen, _, _ = p.scan()
 
 	// Only parse aliases for nested select statements.
-	if _, ok := source.X.(*SelectStatement); ok && (p.peek() == AS || isIdentToken(p.peek())) {
+	if p.peek() == AS || isIdentToken(p.peek()) {
 		if p.peek() == AS {
 			source.As, _, _ = p.scan()
 		}

--- a/parser.go
+++ b/parser.go
@@ -2139,7 +2139,6 @@ func (p *Parser) parseParenSource() (_ *ParenSource, err error) {
 	}
 	source.Rparen, _, _ = p.scan()
 
-	// Only parse aliases for nested select statements.
 	if p.peek() == AS || isIdentToken(p.peek()) {
 		if p.peek() == AS {
 			source.As, _, _ = p.scan()

--- a/parser_test.go
+++ b/parser_test.go
@@ -1933,6 +1933,21 @@ func TestParser_ParseStatement(t *testing.T) {
 				Rparen: pos(28),
 			},
 		})
+		AssertParseStatement(t, `SELECT * FROM ( t ) a`, &sql.SelectStatement{
+			Select: pos(0),
+			Columns: []*sql.ResultColumn{
+				{Star: pos(7)},
+			},
+			From: pos(9),
+			Source: &sql.ParenSource{
+				Lparen: pos(14),
+				X: &sql.QualifiedTableName{
+					Name: &sql.Ident{NamePos: pos(16), Name: "t"},
+				},
+				Rparen: pos(18),
+				Alias:  &sql.Ident{NamePos: pos(20), Name: "a"},
+			},
+		})
 
 		AssertParseStatement(t, `SELECT * FROM foo, bar`, &sql.SelectStatement{
 			Select: pos(0),


### PR DESCRIPTION
According to the spec this type of aliasing is allowed even in non-nested select statements:
```sql
FROM ( col1 ) alias1
```

Here is the language [diagram](https://sqlite.org/syntax/table-or-subquery.html) for the FROM clause. I assume the spec looked different back then when [benbjohnson](https://github.com/benbjohnson) worked on it