### PR TITLE
Fix so hex integer literals scanned properly

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -1691,6 +1691,14 @@ func TestParser_ParseStatement(t *testing.T) {
 				},
 			},
 		})
+		AssertParseStatement(t, `SELECT 0xe3`, &sql.SelectStatement{
+			Select: pos(0),
+			Columns: []*sql.ResultColumn{
+				{
+					Expr: &sql.NumberLit{ValuePos: pos(7), Value: "0xe3"},
+				},
+			},
+		})
 
 		AssertParseStatement(t, `SELECT datetime('now')`, &sql.SelectStatement{
 			Select: pos(0),

--- a/parser_test.go
+++ b/parser_test.go
@@ -1691,14 +1691,6 @@ func TestParser_ParseStatement(t *testing.T) {
 				},
 			},
 		})
-		AssertParseStatement(t, `SELECT 0xe3`, &sql.SelectStatement{
-			Select: pos(0),
-			Columns: []*sql.ResultColumn{
-				{
-					Expr: &sql.NumberLit{ValuePos: pos(7), Value: "0xe3"},
-				},
-			},
-		})
 
 		AssertParseStatement(t, `SELECT datetime('now')`, &sql.SelectStatement{
 			Select: pos(0),

--- a/scanner.go
+++ b/scanner.go
@@ -279,6 +279,16 @@ func (s *Scanner) scanNumber() (Pos, Token, string) {
 		}
 	}
 
+	if s.peek() == 'x' || s.peek() == 'X' {
+		s.read()
+		s.buf.WriteRune('x')
+		for isHex(s.peek()) {
+			ch, _ := s.read()
+			s.buf.WriteRune(ch)
+		}
+		return pos, tok, s.buf.String()
+	}
+
 	// Read decimal and successive digits.
 	if s.peek() == '.' {
 		tok = FLOAT

--- a/scanner.go
+++ b/scanner.go
@@ -288,7 +288,6 @@ func (s *Scanner) scanNumber() (Pos, Token, string) {
 			// reason: according to spec maximum of 16 significant digits)
 			return pos, tok, s.buf.String()
 		}
-		return pos, tok, s.buf.String()
 	}
 
 	// Read whole number if starting with a digit.

--- a/scanner.go
+++ b/scanner.go
@@ -271,22 +271,32 @@ func (s *Scanner) scanNumber() (Pos, Token, string) {
 
 	s.buf.Reset()
 
+	if s.peek() == '0' {
+		s.buf.WriteRune('0')
+		s.read()
+		if s.peek() == 'x' || s.peek() == 'X' {
+			s.read()
+			s.buf.WriteRune('x')
+			for isHex(s.peek()) {
+				ch, _ := s.read()
+				s.buf.WriteRune(ch)
+			}
+			// TODO: error handling:
+			// if len(s.buf.String()) < 2 => invalid
+			// reason: means we scanned '0x'
+			// if len(s.buf.String()) - 2 > 16 => invalid
+			// reason: according to spec maximum of 16 significant digits)
+			return pos, tok, s.buf.String()
+		}
+		return pos, tok, s.buf.String()
+	}
+
 	// Read whole number if starting with a digit.
 	if isDigit(s.peek()) {
 		for isDigit(s.peek()) {
 			ch, _ := s.read()
 			s.buf.WriteRune(ch)
 		}
-	}
-
-	if s.peek() == 'x' || s.peek() == 'X' {
-		s.read()
-		s.buf.WriteRune('x')
-		for isHex(s.peek()) {
-			ch, _ := s.read()
-			s.buf.WriteRune(ch)
-		}
-		return pos, tok, s.buf.String()
 	}
 
 	// Read decimal and successive digits.

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -79,6 +79,7 @@ func TestScanner_Scan(t *testing.T) {
 	})
 
 	t.Run("INTEGER", func(t *testing.T) {
+		AssertScan(t, `012`, sql.INTEGER, `012`)
 		AssertScan(t, `123`, sql.INTEGER, `123`)
 		AssertScan(t, `0xe3`, sql.INTEGER, `0xe3`)
 		// BUG: see comment in scanner
@@ -89,6 +90,7 @@ func TestScanner_Scan(t *testing.T) {
 
 	t.Run("FLOAT", func(t *testing.T) {
 		AssertScan(t, `123.456`, sql.FLOAT, `123.456`)
+		AssertScan(t, `0.01`, sql.FLOAT, `0.01`)
 		AssertScan(t, `.1`, sql.FLOAT, `.1`)
 		AssertScan(t, `123e456`, sql.FLOAT, `123e456`)
 		AssertScan(t, `123E456`, sql.FLOAT, `123E456`)

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -81,6 +81,10 @@ func TestScanner_Scan(t *testing.T) {
 	t.Run("INTEGER", func(t *testing.T) {
 		AssertScan(t, `123`, sql.INTEGER, `123`)
 		AssertScan(t, `0xe3`, sql.INTEGER, `0xe3`)
+		// BUG: see comment in scanner
+		// AssertScanError(t, `0x`, sql.ILLEGAL)
+		// AssertScanError(t, `4xe3`, sql.ILLEGAL)
+		// AssertScanError(t, `0x12345678912345678`, sql.ILLEGAL, ``)
 	})
 
 	t.Run("FLOAT", func(t *testing.T) {

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -80,6 +80,7 @@ func TestScanner_Scan(t *testing.T) {
 
 	t.Run("INTEGER", func(t *testing.T) {
 		AssertScan(t, `123`, sql.INTEGER, `123`)
+		AssertScan(t, `0xe3`, sql.INTEGER, `0xe3`)
 	})
 
 	t.Run("FLOAT", func(t *testing.T) {


### PR DESCRIPTION
Before this fix hexadecimal would get scanned incorrectly e.g. the scanner would return `0` for input  `0xe3`. I implemented hexadecimal integer literals using token `INTEGER` within `scanNumber` method as sqlite interprets it this way (see below). I do not perform a check for 16 significant digits as scanner has no error handling.

From the [spec](https://www.sqlite.org/lang_expr.html)
>  Hexadecimal integer literals are interpreted as 64-bit two's-complement integers and are thus limited to sixteen significant digits of precision. Support for hexadecimal integers was added to SQLite version 3.8.6 (2014-08-15). For backwards compatibility, the "0x" hexadecimal integer notation is only understood by the SQL language parser, not by the type conversions routines.


