### PR TITLE
Added CREATE VIRTUAL TABLE

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -11,107 +11,109 @@ type Node interface {
 	fmt.Stringer
 }
 
-func (*AlterTableStatement) node()        {}
-func (*AnalyzeStatement) node()           {}
-func (*Assignment) node()                 {}
-func (*BeginStatement) node()             {}
-func (*BinaryExpr) node()                 {}
-func (*BindExpr) node()                   {}
-func (*BlobLit) node()                    {}
-func (*BoolLit) node()                    {}
-func (*Call) node()                       {}
-func (*CaseBlock) node()                  {}
-func (*CaseExpr) node()                   {}
-func (*CastExpr) node()                   {}
-func (*CheckConstraint) node()            {}
-func (*CollateConstraint) node()          {}
-func (*ColumnDefinition) node()           {}
-func (*CommitStatement) node()            {}
-func (*CreateIndexStatement) node()       {}
-func (*CreateTableStatement) node()       {}
-func (*CreateTriggerStatement) node()     {}
-func (*CreateViewStatement) node()        {}
-func (*DefaultConstraint) node()          {}
-func (*DeleteStatement) node()            {}
-func (*DropIndexStatement) node()         {}
-func (*DropTableStatement) node()         {}
-func (*DropTriggerStatement) node()       {}
-func (*DropViewStatement) node()          {}
-func (*Exists) node()                     {}
-func (*Null) node()                       {}
-func (*ExplainStatement) node()           {}
-func (*ExprList) node()                   {}
-func (*FilterClause) node()               {}
-func (*ForeignKeyArg) node()              {}
-func (*ForeignKeyConstraint) node()       {}
-func (*FrameSpec) node()                  {}
-func (*GeneratedConstraint) node()        {}
-func (*Ident) node()                      {}
-func (*IndexedColumn) node()              {}
-func (*InsertStatement) node()            {}
-func (*JoinClause) node()                 {}
-func (*JoinOperator) node()               {}
-func (*NotNullConstraint) node()          {}
-func (*NullLit) node()                    {}
-func (*NumberLit) node()                  {}
-func (*OnConstraint) node()               {}
-func (*OrderingTerm) node()               {}
-func (*OverClause) node()                 {}
-func (*ParenExpr) node()                  {}
-func (*ParenSource) node()                {}
-func (*PragmaStatement) node()            {}
-func (*PrimaryKeyConstraint) node()       {}
-func (*QualifiedRef) node()               {}
-func (*QualifiedTableName) node()         {}
-func (*QualifiedTableFunctionName) node() {}
-func (*Raise) node()                      {}
-func (*Range) node()                      {}
-func (*ReindexStatement) node()           {}
-func (*ReleaseStatement) node()           {}
-func (*ResultColumn) node()               {}
-func (*ReturningClause) node()            {}
-func (*RollbackStatement) node()          {}
-func (*SavepointStatement) node()         {}
-func (*SelectStatement) node()            {}
-func (*StringLit) node()                  {}
-func (*TimestampLit) node()               {}
-func (*Type) node()                       {}
-func (*UnaryExpr) node()                  {}
-func (*UniqueConstraint) node()           {}
-func (*UpdateStatement) node()            {}
-func (*UpsertClause) node()               {}
-func (*UsingConstraint) node()            {}
-func (*Window) node()                     {}
-func (*WindowDefinition) node()           {}
-func (*WithClause) node()                 {}
+func (*AlterTableStatement) node()         {}
+func (*AnalyzeStatement) node()            {}
+func (*Assignment) node()                  {}
+func (*BeginStatement) node()              {}
+func (*BinaryExpr) node()                  {}
+func (*BindExpr) node()                    {}
+func (*BlobLit) node()                     {}
+func (*BoolLit) node()                     {}
+func (*Call) node()                        {}
+func (*CaseBlock) node()                   {}
+func (*CaseExpr) node()                    {}
+func (*CastExpr) node()                    {}
+func (*CheckConstraint) node()             {}
+func (*CollateConstraint) node()           {}
+func (*ColumnDefinition) node()            {}
+func (*CommitStatement) node()             {}
+func (*CreateIndexStatement) node()        {}
+func (*CreateTableStatement) node()        {}
+func (*CreateTriggerStatement) node()      {}
+func (*CreateViewStatement) node()         {}
+func (*CreateVirtualTableStatement) node() {}
+func (*DefaultConstraint) node()           {}
+func (*DeleteStatement) node()             {}
+func (*DropIndexStatement) node()          {}
+func (*DropTableStatement) node()          {}
+func (*DropTriggerStatement) node()        {}
+func (*DropViewStatement) node()           {}
+func (*Exists) node()                      {}
+func (*ExplainStatement) node()            {}
+func (*ExprList) node()                    {}
+func (*FilterClause) node()                {}
+func (*ForeignKeyArg) node()               {}
+func (*ForeignKeyConstraint) node()        {}
+func (*FrameSpec) node()                   {}
+func (*GeneratedConstraint) node()         {}
+func (*Ident) node()                       {}
+func (*IndexedColumn) node()               {}
+func (*InsertStatement) node()             {}
+func (*JoinClause) node()                  {}
+func (*JoinOperator) node()                {}
+func (*NotNullConstraint) node()           {}
+func (*Null) node()                        {}
+func (*NullLit) node()                     {}
+func (*NumberLit) node()                   {}
+func (*OnConstraint) node()                {}
+func (*OrderingTerm) node()                {}
+func (*OverClause) node()                  {}
+func (*ParenExpr) node()                   {}
+func (*ParenSource) node()                 {}
+func (*PragmaStatement) node()             {}
+func (*PrimaryKeyConstraint) node()        {}
+func (*QualifiedRef) node()                {}
+func (*QualifiedTableName) node()          {}
+func (*QualifiedTableFunctionName) node()  {}
+func (*Raise) node()                       {}
+func (*Range) node()                       {}
+func (*ReindexStatement) node()            {}
+func (*ReleaseStatement) node()            {}
+func (*ResultColumn) node()                {}
+func (*ReturningClause) node()             {}
+func (*RollbackStatement) node()           {}
+func (*SavepointStatement) node()          {}
+func (*SelectStatement) node()             {}
+func (*StringLit) node()                   {}
+func (*TimestampLit) node()                {}
+func (*Type) node()                        {}
+func (*UnaryExpr) node()                   {}
+func (*UniqueConstraint) node()            {}
+func (*UpdateStatement) node()             {}
+func (*UpsertClause) node()                {}
+func (*UsingConstraint) node()             {}
+func (*Window) node()                      {}
+func (*WindowDefinition) node()            {}
+func (*WithClause) node()                  {}
 
 type Statement interface {
 	Node
 	stmt()
 }
 
-func (*AlterTableStatement) stmt()    {}
-func (*AnalyzeStatement) stmt()       {}
-func (*BeginStatement) stmt()         {}
-func (*CommitStatement) stmt()        {}
-func (*CreateIndexStatement) stmt()   {}
-func (*CreateTableStatement) stmt()   {}
-func (*CreateTriggerStatement) stmt() {}
-func (*CreateViewStatement) stmt()    {}
-func (*DeleteStatement) stmt()        {}
-func (*DropIndexStatement) stmt()     {}
-func (*DropTableStatement) stmt()     {}
-func (*DropTriggerStatement) stmt()   {}
-func (*DropViewStatement) stmt()      {}
-func (*ExplainStatement) stmt()       {}
-func (*PragmaStatement) stmt()        {}
-func (*InsertStatement) stmt()        {}
-func (*ReindexStatement) stmt()       {}
-func (*ReleaseStatement) stmt()       {}
-func (*RollbackStatement) stmt()      {}
-func (*SavepointStatement) stmt()     {}
-func (*SelectStatement) stmt()        {}
-func (*UpdateStatement) stmt()        {}
+func (*AlterTableStatement) stmt()         {}
+func (*AnalyzeStatement) stmt()            {}
+func (*BeginStatement) stmt()              {}
+func (*CommitStatement) stmt()             {}
+func (*CreateIndexStatement) stmt()        {}
+func (*CreateTableStatement) stmt()        {}
+func (*CreateTriggerStatement) stmt()      {}
+func (*CreateViewStatement) stmt()         {}
+func (*CreateVirtualTableStatement) stmt() {}
+func (*DeleteStatement) stmt()             {}
+func (*DropIndexStatement) stmt()          {}
+func (*DropTableStatement) stmt()          {}
+func (*DropTriggerStatement) stmt()        {}
+func (*DropViewStatement) stmt()           {}
+func (*ExplainStatement) stmt()            {}
+func (*InsertStatement) stmt()             {}
+func (*PragmaStatement) stmt()             {}
+func (*ReindexStatement) stmt()            {}
+func (*ReleaseStatement) stmt()            {}
+func (*RollbackStatement) stmt()           {}
+func (*SavepointStatement) stmt()          {}
+func (*SelectStatement) stmt()             {}
+func (*UpdateStatement) stmt()             {}
 
 // CloneStatement returns a deep copy stmt.
 func CloneStatement(stmt Statement) Statement {
@@ -135,6 +137,8 @@ func CloneStatement(stmt Statement) Statement {
 	case *CreateTriggerStatement:
 		return stmt.Clone()
 	case *CreateViewStatement:
+		return stmt.Clone()
+	case *CreateVirtualTableStatement:
 		return stmt.Clone()
 	case *DeleteStatement:
 		return stmt.Clone()
@@ -1237,6 +1241,112 @@ func (c *ForeignKeyArg) String() string {
 		buf.WriteString(" NO ACTION")
 	}
 	return buf.String()
+}
+
+type CreateVirtualTableStatement struct {
+	Create      Pos // position of CREATE keyword
+	Virtual     Pos // position of VIRTUAL keyword
+	Table       Pos // position of TABLE keyword
+	If          Pos // position of IF keyword (optional)
+	IfNot       Pos // position of NOT keyword (optional)
+	IfNotExists Pos // position of EXISTS keyword (optional)
+
+	Schema *Ident // schema name (optional)
+	Dot    Pos    // position of DOT token (optional)
+	Name   *Ident // table name
+
+	Using      Pos    // position of USING
+	ModuleName *Ident // name of an object that implements the virtual table
+
+	Lparen    Pos               // position of left paren of module argument list (optional)
+	Arguments []*ModuleArgument // module argument list (optional)
+	Rparen    Pos               // position of right paren of module argument list (optional)
+
+}
+
+// Clone returns a deep copy of s.
+func (s *CreateVirtualTableStatement) Clone() *CreateVirtualTableStatement {
+	if s == nil {
+		return s
+	}
+	other := *s
+	other.Schema = s.Name.Clone()
+	other.Name = s.Name.Clone()
+	other.ModuleName = s.ModuleName.Clone()
+	other.Arguments = cloneModuleArguments(s.Arguments)
+	return &other
+}
+
+// String returns the string representation of the statement.
+func (s *CreateVirtualTableStatement) String() string {
+	var buf bytes.Buffer
+	buf.WriteString("CREATE VIRTUAL TABLE ")
+	if s.IfNotExists.IsValid() {
+		buf.WriteString("IF NOT EXISTS ")
+	}
+
+	if s.Schema != nil {
+		buf.WriteString(s.Schema.String())
+		buf.WriteString(".")
+	}
+	buf.WriteString(s.Name.String())
+
+	buf.WriteString(" USING ")
+	buf.WriteString(s.ModuleName.String())
+	if s.Lparen.IsValid() {
+		buf.WriteString(" (")
+		for i := range s.Arguments {
+			if i != 0 {
+				buf.WriteString(",")
+			}
+			buf.WriteString(s.Arguments[i].String())
+		}
+		buf.WriteString(")")
+	}
+	return buf.String()
+}
+
+type ModuleArgument struct {
+	Name    *Ident // argument name
+	Assign  Pos    // position of ASSIGN token (optional)
+	Literal Expr   // literal that is assigned to name (optional)
+	Type    *Type  // type of Name, if Assign is set then Type cant be (optional)
+}
+
+func (a *ModuleArgument) Clone() *ModuleArgument {
+	if a == nil {
+		return a
+	}
+	other := *a
+	other.Name = a.Name.Clone()
+	other.Literal = CloneExpr(a.Literal)
+	other.Type = a.Type.Clone()
+	return &other
+}
+
+func (a *ModuleArgument) String() string {
+	var buf bytes.Buffer
+
+	buf.WriteString(a.Name.String())
+	if a.Assign.IsValid() {
+		buf.WriteString("=")
+		buf.WriteString(a.Literal.String())
+	} else if a.Type != nil {
+		buf.WriteString(" ")
+		buf.WriteString(a.Type.String())
+	}
+
+	return buf.String()
+}
+func cloneModuleArguments(a []*ModuleArgument) []*ModuleArgument {
+	if a == nil {
+		return nil
+	}
+	other := make([]*ModuleArgument, len(a))
+	for i := range a {
+		other[i] = a[i].Clone()
+	}
+	return other
 }
 
 type AnalyzeStatement struct {

--- a/ast.go
+++ b/ast.go
@@ -51,6 +51,7 @@ func (*IndexedColumn) node()               {}
 func (*InsertStatement) node()             {}
 func (*JoinClause) node()                  {}
 func (*JoinOperator) node()                {}
+func (*ModuleArgument) node()              {}
 func (*NotNullConstraint) node()           {}
 func (*Null) node()                        {}
 func (*NullLit) node()                     {}

--- a/parser.go
+++ b/parser.go
@@ -247,6 +247,8 @@ func (p *Parser) parseCreateStatement() (Statement, error) {
 	switch p.peek() {
 	case TABLE:
 		return p.parseCreateTableStatement(pos)
+	case VIRTUAL:
+		return p.parseCreateVirtualTableStatement(pos)
 	case VIEW:
 		return p.parseCreateViewStatement(pos)
 	case INDEX, UNIQUE:
@@ -844,6 +846,119 @@ func (p *Parser) parseForeignKeyConstraint(constraintPos Pos, name *Ident, isTab
 	}
 
 	return &cons, nil
+}
+
+func (p *Parser) parseCreateVirtualTableStatement(createPos Pos) (_ *CreateVirtualTableStatement, err error) {
+	assert(p.peek() == VIRTUAL)
+
+	var stmt CreateVirtualTableStatement
+	stmt.Create = createPos
+	stmt.Virtual, _, _ = p.scan()
+	stmt.Table, _, _ = p.scan()
+
+	// Parse optional "IF NOT EXISTS".
+	if p.peek() == IF {
+		stmt.If, _, _ = p.scan()
+
+		pos, tok, _ := p.scan()
+		if tok != NOT {
+			return &stmt, p.errorExpected(pos, tok, "NOT")
+		}
+		stmt.IfNot = pos
+
+		pos, tok, _ = p.scan()
+		if tok != EXISTS {
+			return &stmt, p.errorExpected(pos, tok, "EXISTS")
+		}
+		stmt.IfNotExists = pos
+	}
+
+	ident, err := p.parseIdent("schema or table name")
+	if err != nil {
+		return &stmt, err
+	}
+	if p.peek() == DOT {
+		stmt.Schema = ident
+		stmt.Dot, _, _ = p.scan()
+		if stmt.Name, err = p.parseIdent("table name"); err != nil {
+			return &stmt, err
+		}
+	} else {
+		stmt.Name = ident
+	}
+
+	pos, tok, _ := p.scan()
+	if tok != USING {
+		return &stmt, p.errorExpected(p.pos, p.tok, "USING")
+	}
+	stmt.Using = pos
+
+	if stmt.ModuleName, err = p.parseIdent("module name"); err != nil {
+		return &stmt, err
+	}
+	// Module arguments can be optional
+	if p.peek() != LP {
+		return &stmt, nil
+	}
+	stmt.Lparen, _, _ = p.scan()
+
+	if stmt.Arguments, err = p.parseModuleArguments(); err != nil {
+		return &stmt, err
+	}
+
+	if len(stmt.Arguments) == 0 {
+		return &stmt, p.errorExpected(p.pos, p.tok, "module arguments")
+	}
+
+	if p.peek() != RP {
+		return &stmt, p.errorExpected(p.pos, p.tok, "right paren")
+	}
+	stmt.Rparen, _, _ = p.scan()
+
+	return &stmt, nil
+}
+
+func (p *Parser) parseModuleArguments() (_ []*ModuleArgument, err error) {
+	var args []*ModuleArgument
+
+	for p.peek() != RP {
+		arg, err := p.parseModuleArgument()
+		if err != nil {
+			return args, err
+		}
+		args = append(args, arg)
+
+		if p.peek() == COMMA {
+			p.scan()
+		} else if p.peek() != RP {
+			return args, p.errorExpected(p.pos, p.tok, "comma or right paren")
+		}
+	}
+
+	return args, nil
+}
+
+func (p *Parser) parseModuleArgument() (_ *ModuleArgument, err error) {
+	var arg ModuleArgument
+
+	if arg.Name, err = p.parseIdent("module argument name"); err != nil {
+		return &arg, err
+	}
+
+	if p.peek() == EQ {
+		// Parse literal
+		arg.Assign, _, _ = p.scan()
+		if arg.Literal, err = p.parseOperand(); err != nil {
+			return &arg, err
+		}
+	} else if isTypeName(p.lit) {
+		if arg.Type, err = p.parseType(); err != nil {
+			return &arg, err
+		}
+
+	}
+
+	return &arg, nil
 }
 
 func (p *Parser) parseDropTableStatement(dropPos Pos) (_ *DropTableStatement, err error) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -1371,6 +1371,122 @@ func TestParser_ParseStatement(t *testing.T) {
 		})
 	})
 
+	t.Run("CreateVirtualTable", func(t *testing.T) {
+		AssertParseStatement(t, `CREATE VIRTUAL TABLE vtbl USING mdl`, &sql.CreateVirtualTableStatement{
+			Create:     pos(0),
+			Virtual:    pos(7),
+			Table:      pos(15),
+			Name:       &sql.Ident{NamePos: pos(21), Name: "vtbl"},
+			Using:      pos(26),
+			ModuleName: &sql.Ident{NamePos: pos(32), Name: "mdl"},
+		})
+
+		AssertParseStatementError(t, `CREATE VIRTUAL TABLE vtbl`, "1:25: expected USING, found 'EOF'")
+		AssertParseStatementError(t, `CREATE VIRTUAL TABLE vtbl USING`, "1:31: expected module name, found 'EOF'")
+
+		t.Run("WithSchemaQualifiedTable", func(t *testing.T) {
+			AssertParseStatement(t, `CREATE VIRTUAL TABLE schm.vtbl USING mdl`, &sql.CreateVirtualTableStatement{
+				Create:     pos(0),
+				Virtual:    pos(7),
+				Table:      pos(15),
+				Schema:     &sql.Ident{NamePos: pos(21), Name: "schm"},
+				Dot:        pos(25),
+				Name:       &sql.Ident{NamePos: pos(26), Name: "vtbl"},
+				Using:      pos(31),
+				ModuleName: &sql.Ident{NamePos: pos(37), Name: "mdl"},
+			})
+			AssertParseStatementError(t, `CREATE VIRTUAL TABLE schm.`, "1:26: expected table name, found 'EOF'")
+			AssertParseStatementError(t, `CREATE VIRTUAL TABLE schm.vtbl`, "1:30: expected USING, found 'EOF'")
+		})
+
+		t.Run("WithIfNotExists", func(t *testing.T) {
+			AssertParseStatement(t, `CREATE VIRTUAL TABLE IF NOT EXISTS vtbl USING mdl`, &sql.CreateVirtualTableStatement{
+				Create:      pos(0),
+				Virtual:     pos(7),
+				Table:       pos(15),
+				If:          pos(21),
+				IfNot:       pos(24),
+				IfNotExists: pos(28),
+				Name:        &sql.Ident{NamePos: pos(35), Name: "vtbl"},
+				Using:       pos(40),
+				ModuleName:  &sql.Ident{NamePos: pos(46), Name: "mdl"},
+			})
+			AssertParseStatementError(t, `CREATE VIRTUAL TABLE IF`, "1:23: expected NOT, found 'EOF'")
+			AssertParseStatementError(t, `CREATE VIRTUAL TABLE IF NOT`, "1:27: expected EXISTS, found 'EOF'")
+			AssertParseStatementError(t, `CREATE VIRTUAL TABLE IF NOT EXIST`, "1:29: expected EXISTS, found EXIST")
+			AssertParseStatementError(t, `CREATE VIRTUAL TABLE IF NOT EXISTS`, "1:34: expected schema or table name, found 'EOF'")
+		})
+
+		t.Run("WithArguments", func(t *testing.T) {
+			AssertParseStatement(t, `CREATE VIRTUAL TABLE vtbl USING mdl(arg1)`, &sql.CreateVirtualTableStatement{
+				Create:     pos(0),
+				Virtual:    pos(7),
+				Table:      pos(15),
+				Name:       &sql.Ident{NamePos: pos(21), Name: "vtbl"},
+				Using:      pos(26),
+				ModuleName: &sql.Ident{NamePos: pos(32), Name: "mdl"},
+				Lparen:     pos(35),
+				Arguments: []*sql.ModuleArgument{
+					{Name: &sql.Ident{NamePos: pos(36), Name: "arg1"}},
+				},
+				Rparen: pos(40),
+			})
+			AssertParseStatement(t, `CREATE VIRTUAL TABLE vtbl USING mdl(arg1,arg2='a',"arg3"=false)`, &sql.CreateVirtualTableStatement{
+				Create:     pos(0),
+				Virtual:    pos(7),
+				Table:      pos(15),
+				Name:       &sql.Ident{NamePos: pos(21), Name: "vtbl"},
+				Using:      pos(26),
+				ModuleName: &sql.Ident{NamePos: pos(32), Name: "mdl"},
+				Lparen:     pos(35),
+				Arguments: []*sql.ModuleArgument{
+					{
+						Name: &sql.Ident{NamePos: pos(36), Name: "arg1"},
+					},
+					{
+						Name:    &sql.Ident{NamePos: pos(41), Name: "arg2"},
+						Assign:  pos(45),
+						Literal: &sql.StringLit{ValuePos: pos(46), Value: "a"},
+					},
+					{
+						Name:    &sql.Ident{NamePos: pos(50), Name: "arg3", Quoted: true},
+						Assign:  pos(56),
+						Literal: &sql.BoolLit{ValuePos: pos(57), Value: false},
+					},
+				},
+				Rparen: pos(62),
+			})
+			AssertParseStatement(t, `CREATE VIRTUAL TABLE vtbl USING mdl(arg1 TEXT)`, &sql.CreateVirtualTableStatement{
+				Create:     pos(0),
+				Virtual:    pos(7),
+				Table:      pos(15),
+				Name:       &sql.Ident{NamePos: pos(21), Name: "vtbl"},
+				Using:      pos(26),
+				ModuleName: &sql.Ident{NamePos: pos(32), Name: "mdl"},
+				Lparen:     pos(35),
+				Arguments: []*sql.ModuleArgument{
+					{
+						Name: &sql.Ident{NamePos: pos(36), Name: "arg1"},
+						Type: &sql.Type{Name: &sql.Ident{NamePos: pos(41), Name: "TEXT"}},
+					},
+				},
+				Rparen: pos(45),
+			})
+
+			AssertParseStatementError(t, `CREATE VIRTUAL TABLE vtbl USING mdl(`, "1:36: expected module argument name, found 'EOF'")
+			AssertParseStatementError(t, `CREATE VIRTUAL TABLE vtbl USING mdl(arg1`, "1:40: expected comma or right paren, found 'EOF'")
+			AssertParseStatementError(t, `CREATE VIRTUAL TABLE vtbl USING mdl(arg1=3`, "1:42: expected comma or right paren, found 'EOF'")
+			AssertParseStatementError(t, `CREATE VIRTUAL TABLE vtbl USING mdl(arg1=3,`, "1:43: expected module argument name, found 'EOF'")
+			AssertParseStatementError(t, `CREATE VIRTUAL TABLE vtbl USING mdl()`, "1:37: expected module arguments, found ')'")
+			AssertParseStatementError(t, `CREATE VIRTUAL TABLE vtbl USING mdl(arg1 BLOB`, "1:45: expected comma or right paren, found 'EOF'")
+			AssertParseStatementError(t, `CREATE VIRTUAL TABLE vtbl USING mdl(arg1 arg2)`, "1:42: expected comma or right paren, found arg2")
+			AssertParseStatementError(t, `CREATE VIRTUAL TABLE vtbl USING mdl(arg1 TEXT=value)`, "1:46: expected comma or right paren, found '='")
+			AssertParseStatementError(t, `CREATE VIRTUAL TABLE vtbl USING mdl(=)`, "1:37: expected module argument name, found '='")
+			AssertParseStatementError(t, `CREATE VIRTUAL TABLE vtbl USING mdl(key=)`, "1:41: expected expression, found ')'")
+			AssertParseStatementError(t, `CREATE VIRTUAL TABLE vtbl USING mdl(=value)`, "1:37: expected module argument name, found '='")
+		})
+	})
+
 	t.Run("DropTable", func(t *testing.T) {
 		AssertParseStatement(t, `DROP TABLE vw`, &sql.DropTableStatement{
 			Drop:  pos(0),


### PR DESCRIPTION
Parser now supports `CREATE VIRTUAL TABLE` e.g.:
```
CREATE VIRTUAL TABLE documents USING fts5(
    title, 
    content, 
    author,
    tokenize='porter ascii',
    content_rowid='id'
);

CREATE VIRTUAL TABLE demo_index USING rtree(
   id,              
   minX, maxX,      
   minY, maxY       
)
```
The parse method supports all possibilities as described in language diagram in [spec](https://www.sqlite.org/lang_createvtab.html).  

I decided to implement a new node called `CreateVirtualTableStatement` as the virtual table struct fields are different enough from a normal table. I have also added unit tests; let me know if there are ones you deem redundant or if anything is missing especially when testing parse errors.