### PR TITLE
Fixed incorrect BITNOT operator

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -1556,6 +1556,8 @@ func (expr *UnaryExpr) String() string {
 		return "-" + expr.X.String()
 	case NOT:
 		return "NOT " + expr.X.String()
+	case BITNOT:
+		return "~" + expr.X.String()
 	default:
 		panic(fmt.Sprintf("sql.UnaryExpr.String(): invalid op %s", expr.Op))
 	}

--- a/parser.go
+++ b/parser.go
@@ -2367,7 +2367,7 @@ func (p *Parser) parseOperand() (expr Expr, err error) {
 		return &BoolLit{ValuePos: pos, Value: tok == TRUE}, nil
 	case tok == BIND:
 		return &BindExpr{NamePos: pos, Name: lit}, nil
-	case tok == PLUS, tok == MINUS:
+	case tok == PLUS, tok == MINUS, tok == BITNOT:
 		expr, err = p.parseOperand()
 		if err != nil {
 			return nil, err

--- a/parser_test.go
+++ b/parser_test.go
@@ -3673,6 +3673,7 @@ func TestParser_ParseExpr(t *testing.T) {
 	t.Run("UnaryExpr", func(t *testing.T) {
 		AssertParseExpr(t, `-123`, &sql.UnaryExpr{OpPos: pos(0), Op: sql.MINUS, X: &sql.NumberLit{ValuePos: pos(1), Value: `123`}})
 		AssertParseExpr(t, `NOT foo`, &sql.UnaryExpr{OpPos: pos(0), Op: sql.NOT, X: &sql.Ident{NamePos: pos(4), Name: "foo"}})
+		AssertParseExpr(t, `~1`, &sql.UnaryExpr{OpPos: pos(0), Op: sql.BITNOT, X: &sql.NumberLit{ValuePos: pos(1), Value: "1"}})
 		AssertParseExprError(t, `-`, `1:1: expected expression, found 'EOF'`)
 	})
 	t.Run("QualifiedRef", func(t *testing.T) {

--- a/scanner.go
+++ b/scanner.go
@@ -58,7 +58,7 @@ func (s *Scanner) Scan() (pos Pos, token Token, lit string) {
 				s.read()
 				return pos, NE, "!="
 			}
-			return pos, BITNOT, "!"
+			return pos, ILLEGAL, "!"
 		case '=':
 			if s.peek() == '=' {
 				s.read()
@@ -119,6 +119,8 @@ func (s *Scanner) Scan() (pos Pos, token Token, lit string) {
 			return pos, SLASH, "/"
 		case '%':
 			return pos, REM, "%"
+		case '~':
+			return pos, BITNOT, "~"
 		default:
 			return pos, ILLEGAL, string(ch)
 		}

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -125,7 +125,7 @@ func TestScanner_Scan(t *testing.T) {
 		AssertScan(t, "<>", sql.NE, "<>")
 	})
 	t.Run("BITNOT", func(t *testing.T) {
-		AssertScan(t, "!", sql.BITNOT, "!")
+		AssertScan(t, "~", sql.BITNOT, "~")
 	})
 	t.Run("EQ", func(t *testing.T) {
 		AssertScan(t, "=", sql.EQ, "=")

--- a/token.go
+++ b/token.go
@@ -61,7 +61,7 @@ const (
 	GE     // >=
 	BITAND // &
 	BITOR  // |
-	BITNOT // !
+	BITNOT // ~
 	LSHIFT // <<
 	RSHIFT // >>
 	PLUS   // +
@@ -278,7 +278,7 @@ var tokens = [...]string{
 	GE:     ">=",
 	BITAND: "&",
 	BITOR:  "|",
-	BITNOT: "!",
+	BITNOT: "~",
 	LSHIFT: "<<",
 	RSHIFT: ">>",
 	PLUS:   "+",


### PR DESCRIPTION
According to spec the three unary ops are `+`, `-` and `~`. See section [2. Operators, and Parse-Affecting Attributes](https://www.sqlite.org/lang_expr.html) in first row of table.  Executing `SELECT !1;` gives an error on SQLite but `SELECT ~1; ` works. 