### PR TITLE
Added IS NULL and NOT NULL postfix operations

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -39,6 +39,7 @@ func (*DropTableStatement) node()         {}
 func (*DropTriggerStatement) node()       {}
 func (*DropViewStatement) node()          {}
 func (*Exists) node()                     {}
+func (*Null) node()                       {}
 func (*ExplainStatement) node()           {}
 func (*ExprList) node()                   {}
 func (*FilterClause) node()               {}
@@ -200,6 +201,7 @@ func (*Call) expr()         {}
 func (*CaseExpr) expr()     {}
 func (*CastExpr) expr()     {}
 func (*Exists) expr()       {}
+func (*Null) expr()         {}
 func (*ExprList) expr()     {}
 func (*Ident) expr()        {}
 func (*NullLit) expr()      {}
@@ -1818,6 +1820,29 @@ func (expr *Exists) String() string {
 		return fmt.Sprintf("NOT EXISTS (%s)", expr.Select.String())
 	}
 	return fmt.Sprintf("EXISTS (%s)", expr.Select.String())
+}
+
+type Null struct {
+	X     Expr  // expression being checked for null
+	Op    Token // IS or NOT token
+	OpPos Pos   // position of NOT NULL postfix operation
+}
+
+// Clone returns a deep copy of expr.
+func (expr *Null) Clone() *Null {
+	if expr == nil {
+		return nil
+	}
+	other := *expr
+	return &other
+}
+
+// String returns the string representation of the expression.
+func (expr *Null) String() string {
+	if expr.Op == ISNULL {
+		return "IS NULL"
+	}
+	return "NOT NULL"
 }
 
 type ExprList struct {

--- a/ast.go
+++ b/ast.go
@@ -1834,6 +1834,7 @@ func (expr *Null) Clone() *Null {
 		return nil
 	}
 	other := *expr
+	other.X = CloneExpr(expr.X)
 	return &other
 }
 

--- a/ast.go
+++ b/ast.go
@@ -238,6 +238,8 @@ func CloneExpr(expr Expr) Expr {
 		return expr.Clone()
 	case *Exists:
 		return expr.Clone()
+	case *Null:
+		return expr.Clone()
 	case *ExprList:
 		return expr.Clone()
 	case *Ident:

--- a/parser.go
+++ b/parser.go
@@ -2424,8 +2424,9 @@ func (p *Parser) parseBinaryExpr(prec1 int) (expr Expr, err error) {
 
 		switch op {
 		case NOTNULL, ISNULL:
-			return &Null{X: x, OpPos: pos, Op: op}, nil
+			x = &Null{X: x, OpPos: pos, Op: op}
 		case IN, NOTIN:
+
 			y, err := p.parseExprList()
 			if err != nil {
 				return x, err

--- a/parser.go
+++ b/parser.go
@@ -2423,6 +2423,8 @@ func (p *Parser) parseBinaryExpr(prec1 int) (expr Expr, err error) {
 		}
 
 		switch op {
+		case NOTNULL, ISNULL:
+			return &Null{X: x, OpPos: pos, Op: op}, nil
 		case IN, NOTIN:
 			y, err := p.parseExprList()
 			if err != nil {
@@ -3154,6 +3156,9 @@ func (p *Parser) scanBinaryOp() (Pos, Token, error) {
 		if p.peek() == NOT {
 			p.scan()
 			return pos, ISNOT, nil
+		} else if p.peek() == NULL {
+			p.scan()
+			return pos, ISNULL, nil
 		}
 		return pos, IS, nil
 	case NOT:
@@ -3176,8 +3181,11 @@ func (p *Parser) scanBinaryOp() (Pos, Token, error) {
 		case BETWEEN:
 			p.scan()
 			return pos, NOTBETWEEN, nil
+		case NULL:
+			p.scan()
+			return pos, NOTNULL, nil
 		default:
-			return pos, tok, p.errorExpected(p.pos, p.tok, "IN, LIKE, GLOB, REGEXP, MATCH, or BETWEEN")
+			return pos, tok, p.errorExpected(p.pos, p.tok, "IN, LIKE, GLOB, REGEXP, MATCH, BETWEEN, IS/NOT NULL")
 		}
 	default:
 		return pos, tok, nil

--- a/parser_test.go
+++ b/parser_test.go
@@ -1816,6 +1816,23 @@ func TestParser_ParseStatement(t *testing.T) {
 				},
 			},
 		})
+		AssertParseStatement(t, `SELECT 1 IS NULL AND false`, &sql.SelectStatement{
+			Select: pos(0),
+			Columns: []*sql.ResultColumn{
+				{
+					Expr: &sql.BinaryExpr{
+						X: &sql.Null{
+							X:     &sql.NumberLit{ValuePos: pos(7), Value: "1"},
+							OpPos: pos(9),
+							Op:    sql.ISNULL,
+						},
+						OpPos: pos(17),
+						Op:    sql.AND,
+						Y:     &sql.BoolLit{ValuePos: pos(21), Value: false},
+					},
+				},
+			},
+		})
 
 		AssertParseStatement(t, `SELECT * FROM tbl`, &sql.SelectStatement{
 			Select: pos(0),

--- a/parser_test.go
+++ b/parser_test.go
@@ -1780,7 +1780,31 @@ func TestParser_ParseStatement(t *testing.T) {
 				},
 			},
 		})
+		AssertParseStatement(t, `SELECT 1 NOTNULL`, &sql.SelectStatement{
+			Select: pos(0),
+			Columns: []*sql.ResultColumn{
+				{
+					Expr: &sql.Null{
+						X:     &sql.NumberLit{ValuePos: pos(7), Value: "1"},
+						OpPos: pos(9),
+						Op:    sql.NOTNULL,
+					},
+				},
+			},
+		})
 		AssertParseStatement(t, `SELECT 1 IS NULL`, &sql.SelectStatement{
+			Select: pos(0),
+			Columns: []*sql.ResultColumn{
+				{
+					Expr: &sql.Null{
+						X:     &sql.NumberLit{ValuePos: pos(7), Value: "1"},
+						OpPos: pos(9),
+						Op:    sql.ISNULL,
+					},
+				},
+			},
+		})
+		AssertParseStatement(t, `SELECT 1 ISNULL`, &sql.SelectStatement{
 			Select: pos(0),
 			Columns: []*sql.ResultColumn{
 				{

--- a/parser_test.go
+++ b/parser_test.go
@@ -1768,6 +1768,31 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 		})
 
+		AssertParseStatement(t, `SELECT 1 NOT NULL`, &sql.SelectStatement{
+			Select: pos(0),
+			Columns: []*sql.ResultColumn{
+				{
+					Expr: &sql.Null{
+						X:     &sql.NumberLit{ValuePos: pos(7), Value: "1"},
+						OpPos: pos(9),
+						Op:    sql.NOTNULL,
+					},
+				},
+			},
+		})
+		AssertParseStatement(t, `SELECT 1 IS NULL`, &sql.SelectStatement{
+			Select: pos(0),
+			Columns: []*sql.ResultColumn{
+				{
+					Expr: &sql.Null{
+						X:     &sql.NumberLit{ValuePos: pos(7), Value: "1"},
+						OpPos: pos(9),
+						Op:    sql.ISNULL,
+					},
+				},
+			},
+		})
+
 		AssertParseStatement(t, `SELECT * FROM tbl`, &sql.SelectStatement{
 			Select: pos(0),
 			Columns: []*sql.ResultColumn{
@@ -3859,7 +3884,7 @@ func TestParser_ParseExpr(t *testing.T) {
 			OpPos: pos(2), Op: sql.NOTMATCH,
 			Y: &sql.NumberLit{ValuePos: pos(12), Value: "2"},
 		})
-		AssertParseExprError(t, `1 NOT TABLE`, `1:7: expected IN, LIKE, GLOB, REGEXP, MATCH, or BETWEEN, found 'TABLE'`)
+		AssertParseExprError(t, `1 NOT TABLE`, `1:7: expected IN, LIKE, GLOB, REGEXP, MATCH, BETWEEN, IS/NOT NULL, found 'TABLE'`)
 		AssertParseExpr(t, `1 IN (2, 3)'`, &sql.BinaryExpr{
 			X:     &sql.NumberLit{ValuePos: pos(0), Value: "1"},
 			OpPos: pos(2), Op: sql.IN,


### PR DESCRIPTION
Sqlite allows `IS NULL` and `NOT NULL` postfix operations on expressions. For example a trivial example:
```
SELECT 1 IS NULL;
SELECT 1 NOT NULL;
```
This is described in the language diagram in [spec](https://www.sqlite.org/lang_expr.html)

Edit: As `ISNULL` and `IS NULL` and `NOTNULL` and `NOT NULL` are considered the same the `(expr *Null) String() string` method outputs `IS NULL` and `NOT NULL`  respectively no matter what variant was parsed. 