### PR TITLE
Added ability to parse NULL column type

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -380,7 +380,7 @@ func (p *Parser) parseColumnDefinition() (_ *ColumnDefinition, err error) {
 		return &col, err
 	}
 
-	if tok := p.peek(); tok == IDENT {
+	if tok := p.peek(); tok == IDENT || tok == NULL {
 		if col.Type, err = p.parseType(); err != nil {
 			return &col, err
 		}
@@ -1217,6 +1217,8 @@ func (p *Parser) parseIdent(desc string) (*Ident, error) {
 	switch tok {
 	case IDENT, QIDENT:
 		return &Ident{Name: lit, NamePos: pos, Quoted: tok == QIDENT}, nil
+	case NULL:
+		return &Ident{Name: lit, NamePos: pos}, nil
 	default:
 		if isBareToken(tok) {
 			return &Ident{Name: lit, NamePos: pos}, nil
@@ -1227,7 +1229,11 @@ func (p *Parser) parseIdent(desc string) (*Ident, error) {
 
 func (p *Parser) parseType() (_ *Type, err error) {
 	var typ Type
-	for p.peek() == IDENT {
+	for {
+		tok := p.peek()
+		if tok != IDENT && tok != NULL {
+			break
+		}
 		typeName, err := p.parseIdent("type name")
 		if err != nil {
 			return &typ, err

--- a/parser_test.go
+++ b/parser_test.go
@@ -488,6 +488,31 @@ func TestParser_ParseStatement(t *testing.T) {
 			Rparen: pos(59),
 		})
 
+		AssertParseStatement(t, "CREATE TABLE t (c1 NULL)", &sql.CreateTableStatement{
+			Create: pos(0),
+			Table:  pos(7),
+			Name: &sql.Ident{
+				NamePos: pos(13),
+				Name:    "t",
+			},
+			Lparen: pos(15),
+			Columns: []*sql.ColumnDefinition{
+				{
+					Name: &sql.Ident{
+						NamePos: pos(16),
+						Name:    "c1",
+					},
+					Type: &sql.Type{
+						Name: &sql.Ident{
+							NamePos: pos(19),
+							Name:    "NULL",
+						},
+					},
+				},
+			},
+			Rparen: pos(23),
+		})
+
 		AssertParseStatementError(t, `CREATE TABLE IF`, `1:15: expected NOT, found 'EOF'`)
 		AssertParseStatementError(t, `CREATE TABLE IF NOT`, `1:19: expected EXISTS, found 'EOF'`)
 		AssertParseStatementError(t, `CREATE TABLE tbl (col1`, `1:22: expected column name, CONSTRAINT, or right paren, found 'EOF'`)


### PR DESCRIPTION
I added  support for NULL type in column definitions.  We should be able to parse this as it is supported by SQLite:
```sql
CREATE TABLE t0 (c1 NULL);
```

I had to implement it this way, as NULL is a token and not parsed as an IDENT. I dont think we should change the way the scanner identifies NULL as having it as a separate token is useful for null constraint parsing and IS NULL etc.