### PR TITLE
Added PRAGMA statement

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -59,6 +59,7 @@ func (*OrderingTerm) node()               {}
 func (*OverClause) node()                 {}
 func (*ParenExpr) node()                  {}
 func (*ParenSource) node()                {}
+func (*PragmaStatement) node()            {}
 func (*PrimaryKeyConstraint) node()       {}
 func (*QualifiedRef) node()               {}
 func (*QualifiedTableName) node()         {}
@@ -103,6 +104,7 @@ func (*DropTableStatement) stmt()     {}
 func (*DropTriggerStatement) stmt()   {}
 func (*DropViewStatement) stmt()      {}
 func (*ExplainStatement) stmt()       {}
+func (*PragmaStatement) stmt()        {}
 func (*InsertStatement) stmt()        {}
 func (*ReleaseStatement) stmt()       {}
 func (*RollbackStatement) stmt()      {}
@@ -3691,6 +3693,37 @@ func (d *WindowDefinition) String() string {
 	}
 
 	buf.WriteString(")")
+
+	return buf.String()
+}
+
+type PragmaStatement struct {
+	Pragma Pos    // position of PRAGMA keyword
+	Schema *Ident // name of schema (optional)
+	Dot    Pos    // position of DOT token (optional)
+	Expr   Expr   // can be Ident, Call or BinaryExpr
+}
+
+func (s *PragmaStatement) Clone() *PragmaStatement {
+	if s == nil {
+		return s
+	}
+
+	other := *s
+	other.Schema = s.Schema.Clone()
+	other.Expr = CloneExpr(s.Expr)
+	return &other
+}
+
+func (s *PragmaStatement) String() string {
+	var buf bytes.Buffer
+
+	buf.WriteString("PRAGMA ")
+	if s.Schema != nil {
+		buf.WriteString(s.Schema.String())
+		buf.WriteString(".")
+	}
+	buf.WriteString(s.Expr.String())
 
 	return buf.String()
 }

--- a/ast.go
+++ b/ast.go
@@ -3706,6 +3706,7 @@ type PragmaStatement struct {
 	Expr   Expr   // can be Ident, Call or BinaryExpr
 }
 
+// Clone returns a deep copy of s.
 func (s *PragmaStatement) Clone() *PragmaStatement {
 	if s == nil {
 		return s
@@ -3717,6 +3718,7 @@ func (s *PragmaStatement) Clone() *PragmaStatement {
 	return &other
 }
 
+// String returns the string representation of the pragma statement.
 func (s *PragmaStatement) String() string {
 	var buf bytes.Buffer
 

--- a/ast.go
+++ b/ast.go
@@ -147,6 +147,8 @@ func CloneStatement(stmt Statement) Statement {
 		return stmt.Clone()
 	case *ExplainStatement:
 		return stmt.Clone()
+	case *PragmaStatement:
+		return stmt.Clone()
 	case *InsertStatement:
 		return stmt.Clone()
 	case *ReleaseStatement:

--- a/parser.go
+++ b/parser.go
@@ -3100,7 +3100,7 @@ func (p *Parser) parsePragmaStatement() (_ *PragmaStatement, err error) {
 	var stmt PragmaStatement
 	stmt.Pragma, _, _ = p.scan()
 
-	lit, err := p.parseIdent("schema or table name")
+	lit, err := p.parseIdent("schema name")
 	if err != nil {
 		return &stmt, err
 	}
@@ -3109,7 +3109,7 @@ func (p *Parser) parsePragmaStatement() (_ *PragmaStatement, err error) {
 	if p.peek() == DOT {
 		stmt.Schema = lit
 		stmt.Dot, _, _ = p.scan()
-		if lit, err = p.parseIdent("table name"); err != nil {
+		if lit, err = p.parseIdent("pragma name"); err != nil {
 			return &stmt, err
 		}
 	}

--- a/parser.go
+++ b/parser.go
@@ -3288,7 +3288,7 @@ func isConstraintStartToken(tok Token, isTable bool) bool {
 		return true // table & column
 	case FOREIGN:
 		return isTable // table only
-	case NOT, DEFAULT, REFERENCES, GENERATED, AS, COLLATE, NULL:
+	case NOT, DEFAULT, REFERENCES, GENERATED, AS, COLLATE:
 		return !isTable // column only
 	default:
 		return false

--- a/parser.go
+++ b/parser.go
@@ -91,6 +91,8 @@ func (p *Parser) parseExplainStatement() (_ *ExplainStatement, err error) {
 // parseStmt parses all statement types.
 func (p *Parser) parseNonExplainStatement() (Statement, error) {
 	switch p.peek() {
+	case PRAGMA:
+		return p.parsePragmaStatement()
 	case ANALYZE:
 		return p.parseAnalyzeStatement()
 	case REINDEX:
@@ -3092,6 +3094,54 @@ func (p *Parser) parseAlterTableStatement() (_ *AlterTableStatement, err error) 
 	}
 }
 
+func (p *Parser) parsePragmaStatement() (_ *PragmaStatement, err error) {
+	assert(p.peek() == PRAGMA)
+
+	var stmt PragmaStatement
+	stmt.Pragma, _, _ = p.scan()
+
+	lit, err := p.parseIdent("schema or table name")
+	if err != nil {
+		return &stmt, err
+	}
+
+	// Handle <schema>.<pragma-name>
+	if p.peek() == DOT {
+		stmt.Schema = lit
+		stmt.Dot, _, _ = p.scan()
+		if lit, err = p.parseIdent("table name"); err != nil {
+			return &stmt, err
+		}
+	}
+
+	switch p.peek() {
+	case EQ:
+		// Parse as binary expression: pragma-name = value
+		opPos, _, _ := p.scan()
+		rhs, err := p.ParseExpr()
+		if err != nil {
+			return &stmt, err
+		}
+		stmt.Expr = &BinaryExpr{
+			X:     lit,
+			OpPos: opPos,
+			Op:    EQ,
+			Y:     rhs,
+		}
+	case LP:
+		// Parse as function call: pragma-name(args)
+		call, err := p.parseCall(lit)
+		if err != nil {
+			return &stmt, err
+		}
+		stmt.Expr = call
+	default:
+		stmt.Expr = lit
+	}
+
+	return &stmt, nil
+}
+
 func (p *Parser) parseAnalyzeStatement() (_ *AnalyzeStatement, err error) {
 	assert(p.peek() == ANALYZE)
 
@@ -3238,7 +3288,7 @@ func isConstraintStartToken(tok Token, isTable bool) bool {
 		return true // table & column
 	case FOREIGN:
 		return isTable // table only
-	case NOT, DEFAULT, REFERENCES, GENERATED, AS, COLLATE:
+	case NOT, DEFAULT, REFERENCES, GENERATED, AS, COLLATE, NULL:
 		return !isTable // column only
 	default:
 		return false

--- a/parser_test.go
+++ b/parser_test.go
@@ -45,8 +45,8 @@ func TestParser_ParseStatement(t *testing.T) {
 			Expr:   &sql.Ident{NamePos: pos(14), Name: "pragma_name"},
 		})
 
-		AssertParseStatementError(t, `PRAGMA schema.`, "1:14: expected table name, found 'EOF'")
-		AssertParseStatementError(t, `PRAGMA .name`, "1:8: expected schema or table name, found '.'")
+		AssertParseStatementError(t, `PRAGMA schema.`, "1:14: expected pragma name, found 'EOF'")
+		AssertParseStatementError(t, `PRAGMA .name`, "1:8: expected schema name, found '.'")
 		AssertParseStatementError(t, `PRAGMA schema.name=`, "1:19: expected expression, found 'EOF'")
 		AssertParseStatementError(t, `PRAGMA schema.name(`, "1:19: expected expression, found 'EOF'")
 		AssertParseStatementError(t, `PRAGMA schema.name(arg`, "1:22: expected comma or right paren, found 'EOF'")


### PR DESCRIPTION
Parsing of all four variants possible:
```
PRAGMA name;
PRAGMA schema.name;
PRAGMA name=literal;
PRAGMA name(arg);
```
Here is the  [spec](https://www3.sqlite.org/pragma.html) that shows the different variations.