### PR TITLE
Added QualifiedTableFunctionName to CloneSource

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -344,6 +344,8 @@ func CloneSource(src Source) Source {
 		return src.Clone()
 	case *QualifiedTableName:
 		return src.Clone()
+	case *QualifiedTableFunctionName:
+		return src.Clone()
 	case *SelectStatement:
 		return src.Clone()
 	default:


### PR DESCRIPTION
As `QualifiedTableFunctionName` implements the source interface i assume it should also be clonable here? I noticed it is also missing from `ResolveSource` but i am not sure if this is by design