### PR TITLE
Fixed bug in method String() for `Null`

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -1854,10 +1854,16 @@ func (expr *Null) Clone() *Null {
 
 // String returns the string representation of the expression.
 func (expr *Null) String() string {
+	var buf bytes.Buffer
+
+	buf.WriteString(expr.X.String())
 	if expr.Op == ISNULL {
-		return "IS NULL"
+		buf.WriteString(" IS NULL")
+	} else {
+		buf.WriteString(" NOT NULL")
 	}
-	return "NOT NULL"
+
+	return buf.String()
 }
 
 type ExprList struct {

--- a/parser_test.go
+++ b/parser_test.go
@@ -4527,6 +4527,22 @@ func TestParser_ParseExpr(t *testing.T) {
 			},
 			End: pos(19),
 		})
+		AssertParseExpr(t, `CASE WHEN 1 IS NULL THEN 2 END`, &sql.CaseExpr{
+			Case: pos(0),
+			Blocks: []*sql.CaseBlock{
+				{
+					When: pos(5),
+					Condition: &sql.Null{
+						X:     &sql.NumberLit{ValuePos: pos(10), Value: "1"},
+						Op:    sql.ISNULL,
+						OpPos: pos(12),
+					},
+					Then: pos(20),
+					Body: &sql.NumberLit{ValuePos: pos(25), Value: "2"},
+				},
+			},
+			End: pos(27),
+		})
 		AssertParseExprError(t, `CASE`, `1:4: expected expression, found 'EOF'`)
 		AssertParseExprError(t, `CASE 1`, `1:6: expected WHEN, found 'EOF'`)
 		AssertParseExprError(t, `CASE WHEN`, `1:9: expected expression, found 'EOF'`)


### PR DESCRIPTION
It was not writing the expression X to the buffer. I added a unit test