### PR TITLE
Add support for DROP COLUMN in ALTER TABLE statements

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -1436,6 +1436,7 @@ func (s *AlterTableStatement) Clone() *AlterTableStatement {
 	other.ColumnName = s.ColumnName.Clone()
 	other.NewColumnName = s.NewColumnName.Clone()
 	other.ColumnDef = s.ColumnDef.Clone()
+	other.DropColumnName = s.DropColumnName.Clone()
 	return &other
 }
 

--- a/ast.go
+++ b/ast.go
@@ -1412,13 +1412,17 @@ type AlterTableStatement struct {
 	NewName  *Ident // new table name
 
 	RenameColumn  Pos    // position of COLUMN keyword after RENAME
-	ColumnName    *Ident // new column name
+	ColumnName    *Ident // column name
 	To            Pos    // position of TO keyword
 	NewColumnName *Ident // new column name
 
 	Add       Pos               // position of ADD keyword
 	AddColumn Pos               // position of COLUMN keyword after ADD
 	ColumnDef *ColumnDefinition // new column definition
+
+	Drop           Pos    // position of DROP keyword
+	DropColumn     Pos    // position of COLUMN keyword after DROP
+	DropColumnName *Ident // column name to drop
 }
 
 // Clone returns a deep copy of s.
@@ -1452,6 +1456,9 @@ func (s *AlterTableStatement) String() string {
 	} else if s.ColumnDef != nil {
 		buf.WriteString(" ADD COLUMN ")
 		buf.WriteString(s.ColumnDef.String())
+	} else if s.DropColumnName != nil {
+		buf.WriteString(" DROP COLUMN ")
+		buf.WriteString(s.DropColumnName.String())
 	}
 
 	return buf.String()

--- a/ast_test.go
+++ b/ast_test.go
@@ -73,6 +73,11 @@ func TestAlterTableStatement_String(t *testing.T) {
 			Type: &sql.Type{Name: &sql.Ident{Name: "INTEGER"}},
 		},
 	}, `ALTER TABLE "foo" ADD COLUMN "bar" INTEGER`)
+
+	AssertStatementStringer(t, &sql.AlterTableStatement{
+		Name:           &sql.Ident{Name: "foo"},
+		DropColumnName: &sql.Ident{Name: "bar"},
+	}, `ALTER TABLE "foo" DROP COLUMN "bar"`)
 }
 
 func TestAnalyzeStatement_String(t *testing.T) {

--- a/parser.go
+++ b/parser.go
@@ -3276,8 +3276,19 @@ func (p *Parser) parseAlterTableStatement() (_ *AlterTableStatement, err error) 
 			return &stmt, err
 		}
 		return &stmt, nil
+	case DROP:
+		stmt.Drop, _, _ = p.scan()
+		if p.peek() == COLUMN {
+			stmt.DropColumn, _, _ = p.scan()
+		} else if !isIdentToken(p.peek()) {
+			return &stmt, p.errorExpected(p.pos, p.tok, "COLUMN keyword or column name")
+		}
+		if stmt.DropColumnName, err = p.parseIdent("column name"); err != nil {
+			return &stmt, err
+		}
+		return &stmt, nil
 	default:
-		return &stmt, p.errorExpected(p.pos, p.tok, "ADD or RENAME")
+		return &stmt, p.errorExpected(p.pos, p.tok, "ADD, RENAME or DROP")
 	}
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -4042,10 +4042,18 @@ func TestParser_ParseStatement(t *testing.T) {
 				},
 			},
 		})
+		AssertParseStatement(t, `ALTER TABLE tbl DROP COLUMN col`, &sql.AlterTableStatement{
+			Alter:          pos(0),
+			Table:          pos(6),
+			Name:           &sql.Ident{NamePos: pos(12), Name: "tbl"},
+			Drop:           pos(16),
+			DropColumn:     pos(21),
+			DropColumnName: &sql.Ident{NamePos: pos(28), Name: "col"},
+		})
 
 		AssertParseStatementError(t, `ALTER`, `1:5: expected TABLE, found 'EOF'`)
 		AssertParseStatementError(t, `ALTER TABLE`, `1:11: expected table name, found 'EOF'`)
-		AssertParseStatementError(t, `ALTER TABLE tbl`, `1:15: expected ADD or RENAME, found 'EOF'`)
+		AssertParseStatementError(t, `ALTER TABLE tbl`, `1:15: expected ADD, RENAME or DROP, found 'EOF'`)
 		AssertParseStatementError(t, `ALTER TABLE tbl RENAME`, `1:22: expected COLUMN keyword or column name, found 'EOF'`)
 		AssertParseStatementError(t, `ALTER TABLE tbl RENAME TO`, `1:25: expected new table name, found 'EOF'`)
 		AssertParseStatementError(t, `ALTER TABLE tbl RENAME COLUMN`, `1:29: expected column name, found 'EOF'`)
@@ -4053,6 +4061,7 @@ func TestParser_ParseStatement(t *testing.T) {
 		AssertParseStatementError(t, `ALTER TABLE tbl RENAME COLUMN col TO`, `1:36: expected new column name, found 'EOF'`)
 		AssertParseStatementError(t, `ALTER TABLE tbl ADD`, `1:19: expected COLUMN keyword or column name, found 'EOF'`)
 		AssertParseStatementError(t, `ALTER TABLE tbl ADD COLUMN`, `1:26: expected column name, found 'EOF'`)
+		AssertParseStatementError(t, `ALTER TABLE tbl DROP`, `1:20: expected COLUMN keyword or column name, found 'EOF'`)
 	})
 
 	t.Run("Analyze", func(t *testing.T) {


### PR DESCRIPTION
This PR adds support for the `DROP COLUMN` clause in `ALTER TABLE` statements, enabling the parser to handle column deletion operations. This enhancement aligns the parser with standard SQL DDL capabilities and completes the ALTER TABLE functionality alongside the existing `RENAME` and `ADD COLUMN` operations.

## Changes

### AST Structure (`ast.go`)
- **Extended `AlterTableStatement` struct** with three new fields:
  - `Drop`: Position of the DROP keyword
  - `DropColumn`: Position of the COLUMN keyword after DROP
  - `DropColumnName`: Identifier for the column to be dropped
- **Updated `String()` method** to generate the correct SQL representation for DROP COLUMN statements

### Parser Logic (`parser.go`)
- **Added `DROP` case** in `parseAlterTableStatement()` to handle the new syntax
- **Implemented parsing logic** that:
  - Accepts optional `COLUMN` keyword after `DROP` (consistent with SQLite syntax)
  - Falls back to requiring an identifier if `COLUMN` is not present
  - Validates proper syntax and provides helpful error messages
- **Updated error messages** to include "DROP" in the list of expected keywords

### Test Coverage
- **Added AST string test** (`ast_test.go`) verifying the `String()` method correctly outputs `ALTER TABLE "foo" DROP COLUMN "bar"`
- **Added parser test** (`parser_test.go`) verifying:
  - Correct parsing of `ALTER TABLE tbl DROP COLUMN col`
  - Proper position tracking for all tokens
  - AST structure is correctly populated
- **Added error test** ensuring appropriate error message when DROP is incomplete

## Syntax Support

The parser now accepts both forms of the DROP COLUMN syntax:
```sql
ALTER TABLE table_name DROP COLUMN column_name
ALTER TABLE table_name DROP column_name
```

This follows SQLite's flexible syntax where the `COLUMN` keyword is optional.

## Testing

All existing tests continue to pass, and new test cases specifically cover:
- ✅ Successful parsing of DROP COLUMN statements
- ✅ String representation generation
- ✅ Error handling for incomplete DROP statements
- ✅ CI checks passing (CircleCI race and test jobs)

## Compatibility

This change is backward compatible and only adds new parsing capabilities without modifying existing functionality for `RENAME` or `ADD COLUMN` operations.
