### PR TITLE
feat: add Backstack ` character as valid `IDENT`

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1382,8 +1382,8 @@ func (p *Parser) parseDropTriggerStatement(dropPos Pos) (_ *DropTriggerStatement
 func (p *Parser) parseIdent(desc string) (*Ident, error) {
 	pos, tok, lit := p.scan()
 	switch tok {
-	case IDENT, QIDENT:
-		return &Ident{Name: lit, NamePos: pos, Quoted: tok == QIDENT}, nil
+	case IDENT, QIDENT, BIDENT:
+		return &Ident{Name: lit, NamePos: pos, Quoted: tok == QIDENT || tok == BIDENT}, nil
 	case NULL:
 		return &Ident{Name: lit, NamePos: pos}, nil
 	default:
@@ -2201,7 +2201,7 @@ func (p *Parser) parseUnarySource() (source Source, err error) {
 	switch p.peek() {
 	case LP:
 		return p.parseParenSource()
-	case IDENT, QIDENT:
+	case IDENT, QIDENT, BIDENT:
 		return p.parseQualifiedTable(true, true, true)
 	case VALUES:
 		return p.parseSelectStatement(false, nil)
@@ -2538,7 +2538,7 @@ func (p *Parser) parseOperand() (expr Expr, err error) {
 	pos, tok, lit := p.scan()
 	switch {
 	case isExprIdentToken(tok):
-		ident := &Ident{Name: lit, NamePos: pos, Quoted: tok == QIDENT}
+		ident := &Ident{Name: lit, NamePos: pos, Quoted: tok == QIDENT || tok == BIDENT}
 		if p.peek() == DOT {
 			return p.parseQualifiedRef(ident)
 		} else if p.peek() == LP {
@@ -2688,7 +2688,7 @@ func (p *Parser) parseQualifiedRef(table *Ident) (_ *QualifiedRef, err error) {
 		expr.Star, _, _ = p.scan()
 	} else if isIdentToken(p.peek()) {
 		pos, tok, lit := p.scan()
-		expr.Column = &Ident{Name: lit, NamePos: pos, Quoted: tok == QIDENT}
+		expr.Column = &Ident{Name: lit, NamePos: pos, Quoted: tok == QIDENT || tok == BIDENT}
 	} else {
 		return &expr, p.errorExpected(p.pos, p.tok, "column name")
 	}
@@ -2785,7 +2785,7 @@ func (p *Parser) parseOverClause() (_ *OverClause, err error) {
 	// If specifying a window name, read it and exit.
 	if isIdentToken(p.peek()) {
 		pos, tok, lit := p.scan()
-		clause.Name = &Ident{Name: lit, NamePos: pos, Quoted: tok == QIDENT}
+		clause.Name = &Ident{Name: lit, NamePos: pos, Quoted: tok == QIDENT || tok == BIDENT}
 		return &clause, nil
 	}
 
@@ -2807,7 +2807,7 @@ func (p *Parser) parseWindowDefinition() (_ *WindowDefinition, err error) {
 	// Read base window name.
 	if isIdentToken(p.peek()) {
 		pos, tok, lit := p.scan()
-		def.Base = &Ident{Name: lit, NamePos: pos, Quoted: tok == QIDENT}
+		def.Base = &Ident{Name: lit, NamePos: pos, Quoted: tok == QIDENT || tok == BIDENT}
 	}
 
 	// Parse "PARTITION BY expr, expr..."

--- a/scanner.go
+++ b/scanner.go
@@ -35,7 +35,7 @@ func (s *Scanner) Scan() (pos Pos, token Token, lit string) {
 			return s.scanBlob()
 		} else if isAlpha(ch) || ch == '_' {
 			return s.scanUnquotedIdent(s.pos, "")
-		} else if ch == '"' {
+		} else if ch == '"' || ch == '`' {
 			return s.scanQuotedIdent()
 		} else if ch == '\'' {
 			return s.scanString()
@@ -143,7 +143,7 @@ func (s *Scanner) scanUnquotedIdent(pos Pos, prefix string) (Pos, Token, string)
 
 func (s *Scanner) scanQuotedIdent() (Pos, Token, string) {
 	ch, pos := s.read()
-	assert(ch == '"')
+	assert(ch == '"' || ch == '`')
 
 	s.buf.Reset()
 	for {
@@ -157,6 +157,13 @@ func (s *Scanner) scanQuotedIdent() (Pos, Token, string) {
 				continue
 			}
 			return pos, QIDENT, s.buf.String()
+		} else if ch == '`' {
+			if s.peek() == '`' { // escaped quote
+				s.read()
+				s.buf.WriteRune('`')
+				continue
+			}
+			return pos, BIDENT, s.buf.String()
 		}
 		s.buf.WriteRune(ch)
 	}

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -15,6 +15,9 @@ func TestScanner_Scan(t *testing.T) {
 		t.Run("Quoted", func(t *testing.T) {
 			AssertScan(t, `"crazy ~!#*&# column name"" foo"`, sql.QIDENT, `crazy ~!#*&# column name" foo`)
 		})
+		t.Run("BacktickQuoted", func(t *testing.T) {
+			AssertScan(t, "`crazy ~!#*&# column name foo`", sql.BIDENT, `crazy ~!#*&# column name foo`)
+		})
 		t.Run("NoEndQuote", func(t *testing.T) {
 			AssertScan(t, `"unfinished`, sql.ILLEGAL, `"unfinished`)
 		})

--- a/token.go
+++ b/token.go
@@ -38,6 +38,7 @@ const (
 	literal_beg
 	IDENT   // IDENT
 	QIDENT  // "IDENT"
+	BIDENT  // `IDENT`
 	STRING  // 'string'
 	BLOB    // ???
 	FLOAT   // 123.45
@@ -257,6 +258,7 @@ var tokens = [...]string{
 
 	IDENT:   "IDENT",
 	QIDENT:  "QIDENT",
+	BIDENT:  "BIDENT",
 	STRING:  "STRING",
 	BLOB:    "BLOB",
 	FLOAT:   "FLOAT",
@@ -512,17 +514,17 @@ func (tok Token) IsBinaryOp() bool {
 }
 
 func isIdentToken(tok Token) bool {
-	return tok == IDENT || tok == QIDENT
+	return tok == IDENT || tok == QIDENT || tok == BIDENT
 }
 
 // isExprIdentToken returns true if tok can be used as an identifier in an expression.
-// It includes IDENT, QIDENT, bare tokens (keywords that can be used as identifiers),
+// It includes IDENT, QIDENT, BIDENT, bare tokens (keywords that can be used as identifiers),
 // and certain other keywords like ROWID.
 // Note: Some bare tokens have special expression handling (CAST, CASE, RAISE, etc.)
 // and should not be treated as identifiers in parseOperand.
 func isExprIdentToken(tok Token) bool {
 	switch tok {
-	case IDENT, QIDENT:
+	case IDENT, QIDENT, BIDENT:
 		return true
 	// ROWID is a special keyword that can be used as an identifier but is not a bare token
 	case ROWID:


### PR DESCRIPTION
I'm using this library to parse SQL for the project https://github.com/litesql/pocketbase-ha. PocketBase uses backticks (`) in its schema, and this PR adds support for those characters.