### PR TITLE
Fix JoinClause.String() for 4+ joins

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -3611,79 +3611,58 @@ func (c *JoinClause) Clone() *JoinClause {
 func (c *JoinClause) String() string {
 	var buf bytes.Buffer
 
-	// Print the left side
+	// Print the first table and operator.
 	buf.WriteString(c.X.String())
-
-	// Print the operator
 	buf.WriteString(c.Operator.String())
 
-	// Handle the right side
-	if y, ok := c.Y.(*JoinClause); ok {
-		// Special case: right side is a JoinClause
-
-		// Check if the X of the nested JoinClause is also a JoinClause
-		if yx, ok := y.X.(*JoinClause); ok {
-			// Handle the double-nested case
-
-			// Print the first table of the inner JoinClause
-			buf.WriteString(yx.X.String())
-
-			// Add the constraint for the first join
-			if c.Constraint != nil {
-				fmt.Fprintf(&buf, " %s", c.Constraint.String())
-			}
-
-			// Print the operator of the inner JoinClause
-			buf.WriteString(yx.Operator.String())
-
-			// Print the second table of the inner JoinClause
-			buf.WriteString(yx.Y.String())
-
-			// Add the constraint for the inner JoinClause
-			if yx.Constraint != nil {
-				fmt.Fprintf(&buf, " %s", yx.Constraint.String())
-			}
-
-			// Print the operator of the outer JoinClause
-			buf.WriteString(y.Operator.String())
-
-			// Print the right side of the outer JoinClause
-			buf.WriteString(y.Y.String())
-
-			// Add the constraint for the outer JoinClause
-			if y.Constraint != nil {
-				fmt.Fprintf(&buf, " %s", y.Constraint.String())
-			}
-		} else {
-			// Handle the singly-nested case
-
-			// Print the left side of the nested JoinClause
-			buf.WriteString(y.X.String())
-
-			// Add the constraint for the first join
-			if c.Constraint != nil {
-				fmt.Fprintf(&buf, " %s", c.Constraint.String())
-			}
-
-			// Print the operator of the nested JoinClause
-			buf.WriteString(y.Operator.String())
-
-			// Print the right side of the nested JoinClause
-			buf.WriteString(y.Y.String())
-
-			// Add the constraint for the nested JoinClause
-			if y.Constraint != nil {
-				fmt.Fprintf(&buf, " %s", y.Constraint.String())
-			}
-		}
-	} else {
-		// Normal case: right side is not a JoinClause
+	y, ok := c.Y.(*JoinClause)
+	if !ok {
+		// Simple single-join case: print right side and constraint.
 		buf.WriteString(c.Y.String())
-
-		// Add the constraint
 		if c.Constraint != nil {
 			fmt.Fprintf(&buf, " %s", c.Constraint.String())
 		}
+		return buf.String()
+	}
+
+	// Multi-join case: walk down y.X chain collecting intermediate entries.
+	type entry struct {
+		operator   *JoinOperator
+		source     Source
+		constraint JoinConstraint
+	}
+	var stack []entry
+	cur := y.X
+	for {
+		jc, ok := cur.(*JoinClause)
+		if !ok {
+			break
+		}
+		stack = append(stack, entry{jc.Operator, jc.Y, jc.Constraint})
+		cur = jc.X
+	}
+
+	// cur is now the second table (leftmost non-JoinClause in the chain).
+	buf.WriteString(cur.String())
+	if c.Constraint != nil {
+		fmt.Fprintf(&buf, " %s", c.Constraint.String())
+	}
+
+	// Print stack entries in reverse (innermost first).
+	for i := len(stack) - 1; i >= 0; i-- {
+		e := stack[i]
+		buf.WriteString(e.operator.String())
+		buf.WriteString(e.source.String())
+		if e.constraint != nil {
+			fmt.Fprintf(&buf, " %s", e.constraint.String())
+		}
+	}
+
+	// Print the outermost Y entry.
+	buf.WriteString(y.Operator.String())
+	buf.WriteString(y.Y.String())
+	if y.Constraint != nil {
+		fmt.Fprintf(&buf, " %s", y.Constraint.String())
 	}
 
 	return buf.String()

--- a/ast_test.go
+++ b/ast_test.go
@@ -870,6 +870,53 @@ func TestSelectStatement_String(t *testing.T) {
 			},
 		},
 	}, `SELECT * FROM "X" AS "a" JOIN "Y" AS "b" ON "a"."id" = "b"."id" JOIN "Z" AS "c" ON "b"."id" = "c"."id"`)
+
+	// 4-join stringer roundtrip
+	AssertStatementStringer(t, &sql.SelectStatement{
+		Columns: []*sql.ResultColumn{{Star: pos(0)}},
+		Source: &sql.JoinClause{
+			X:        &sql.QualifiedTableName{Name: &sql.Ident{Name: "a"}},
+			Operator: &sql.JoinOperator{},
+			Y: &sql.JoinClause{
+				X: &sql.JoinClause{
+					X:          &sql.QualifiedTableName{Name: &sql.Ident{Name: "b"}},
+					Operator:   &sql.JoinOperator{},
+					Y:          &sql.QualifiedTableName{Name: &sql.Ident{Name: "c"}},
+					Constraint: &sql.OnConstraint{X: &sql.NumberLit{Value: "2"}},
+				},
+				Operator:   &sql.JoinOperator{},
+				Y:          &sql.QualifiedTableName{Name: &sql.Ident{Name: "d"}},
+				Constraint: &sql.OnConstraint{X: &sql.NumberLit{Value: "3"}},
+			},
+			Constraint: &sql.OnConstraint{X: &sql.NumberLit{Value: "1"}},
+		},
+	}, `SELECT * FROM "a" JOIN "b" ON 1 JOIN "c" ON 2 JOIN "d" ON 3`)
+
+	// 5-join stringer roundtrip
+	AssertStatementStringer(t, &sql.SelectStatement{
+		Columns: []*sql.ResultColumn{{Star: pos(0)}},
+		Source: &sql.JoinClause{
+			X:        &sql.QualifiedTableName{Name: &sql.Ident{Name: "a"}},
+			Operator: &sql.JoinOperator{},
+			Y: &sql.JoinClause{
+				X: &sql.JoinClause{
+					X: &sql.JoinClause{
+						X:          &sql.QualifiedTableName{Name: &sql.Ident{Name: "b"}},
+						Operator:   &sql.JoinOperator{},
+						Y:          &sql.QualifiedTableName{Name: &sql.Ident{Name: "c"}},
+						Constraint: &sql.OnConstraint{X: &sql.NumberLit{Value: "2"}},
+					},
+					Operator:   &sql.JoinOperator{},
+					Y:          &sql.QualifiedTableName{Name: &sql.Ident{Name: "d"}},
+					Constraint: &sql.OnConstraint{X: &sql.NumberLit{Value: "3"}},
+				},
+				Operator:   &sql.JoinOperator{},
+				Y:          &sql.QualifiedTableName{Name: &sql.Ident{Name: "e"}},
+				Constraint: &sql.OnConstraint{X: &sql.NumberLit{Value: "4"}},
+			},
+			Constraint: &sql.OnConstraint{X: &sql.NumberLit{Value: "1"}},
+		},
+	}, `SELECT * FROM "a" JOIN "b" ON 1 JOIN "c" ON 2 JOIN "d" ON 3 JOIN "e" ON 4`)
 }
 
 func TestUpdateStatement_String(t *testing.T) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -2520,6 +2520,59 @@ func TestParser_ParseStatement(t *testing.T) {
 				},
 			},
 		})
+		// 4-join roundtrip: parse then verify String() output re-parses to the same result.
+		AssertParseStatement(t, `SELECT * FROM A JOIN B ON 1 JOIN C ON 2 JOIN D ON 3`, &sql.SelectStatement{
+			Select: pos(0),
+			Columns: []*sql.ResultColumn{
+				{Star: pos(7)},
+			},
+			From: pos(9),
+			Source: &sql.JoinClause{
+				X:        &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(14), Name: "A"}},
+				Operator: &sql.JoinOperator{Join: pos(16)},
+				Y: &sql.JoinClause{
+					X: &sql.JoinClause{
+						X:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(21), Name: "B"}},
+						Operator:   &sql.JoinOperator{Join: pos(28)},
+						Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(33), Name: "C"}},
+						Constraint: &sql.OnConstraint{On: pos(35), X: &sql.NumberLit{ValuePos: pos(38), Value: "2"}},
+					},
+					Operator:   &sql.JoinOperator{Join: pos(40)},
+					Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(45), Name: "D"}},
+					Constraint: &sql.OnConstraint{On: pos(47), X: &sql.NumberLit{ValuePos: pos(50), Value: "3"}},
+				},
+				Constraint: &sql.OnConstraint{On: pos(23), X: &sql.NumberLit{ValuePos: pos(26), Value: "1"}},
+			},
+		})
+		// 5-join roundtrip
+		AssertParseStatement(t, `SELECT * FROM A JOIN B ON 1 JOIN C ON 2 JOIN D ON 3 JOIN E ON 4`, &sql.SelectStatement{
+			Select: pos(0),
+			Columns: []*sql.ResultColumn{
+				{Star: pos(7)},
+			},
+			From: pos(9),
+			Source: &sql.JoinClause{
+				X:        &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(14), Name: "A"}},
+				Operator: &sql.JoinOperator{Join: pos(16)},
+				Y: &sql.JoinClause{
+					X: &sql.JoinClause{
+						X: &sql.JoinClause{
+							X:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(21), Name: "B"}},
+							Operator:   &sql.JoinOperator{Join: pos(28)},
+							Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(33), Name: "C"}},
+							Constraint: &sql.OnConstraint{On: pos(35), X: &sql.NumberLit{ValuePos: pos(38), Value: "2"}},
+						},
+						Operator:   &sql.JoinOperator{Join: pos(40)},
+						Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(45), Name: "D"}},
+						Constraint: &sql.OnConstraint{On: pos(47), X: &sql.NumberLit{ValuePos: pos(50), Value: "3"}},
+					},
+					Operator:   &sql.JoinOperator{Join: pos(52)},
+					Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(57), Name: "E"}},
+					Constraint: &sql.OnConstraint{On: pos(59), X: &sql.NumberLit{ValuePos: pos(62), Value: "4"}},
+				},
+				Constraint: &sql.OnConstraint{On: pos(23), X: &sql.NumberLit{ValuePos: pos(26), Value: "1"}},
+			},
+		})
 		AssertParseStatement(t, `SELECT * FROM foo LEFT OUTER JOIN bar`, &sql.SelectStatement{
 			Select: pos(0),
 			Columns: []*sql.ResultColumn{


### PR DESCRIPTION
Replace hardcoded two-level nesting in JoinClause.String() with a general algorithm that walks the y.X chain to handle arbitrary join depth. The previous implementation only handled up to 3 joins, producing scrambled output for 4 or more.