### PR TITLE
Build left-nested AST for multi-way JOINs

### DIFF
--- a/ast.go
+++ b/ast.go
@@ -3610,82 +3610,12 @@ func (c *JoinClause) Clone() *JoinClause {
 // String returns the string representation of the clause.
 func (c *JoinClause) String() string {
 	var buf bytes.Buffer
-
-	// Print the left side
 	buf.WriteString(c.X.String())
-
-	// Print the operator
 	buf.WriteString(c.Operator.String())
-
-	// Handle the right side
-	if y, ok := c.Y.(*JoinClause); ok {
-		// Special case: right side is a JoinClause
-
-		// Check if the X of the nested JoinClause is also a JoinClause
-		if yx, ok := y.X.(*JoinClause); ok {
-			// Handle the double-nested case
-
-			// Print the first table of the inner JoinClause
-			buf.WriteString(yx.X.String())
-
-			// Add the constraint for the first join
-			if c.Constraint != nil {
-				fmt.Fprintf(&buf, " %s", c.Constraint.String())
-			}
-
-			// Print the operator of the inner JoinClause
-			buf.WriteString(yx.Operator.String())
-
-			// Print the second table of the inner JoinClause
-			buf.WriteString(yx.Y.String())
-
-			// Add the constraint for the inner JoinClause
-			if yx.Constraint != nil {
-				fmt.Fprintf(&buf, " %s", yx.Constraint.String())
-			}
-
-			// Print the operator of the outer JoinClause
-			buf.WriteString(y.Operator.String())
-
-			// Print the right side of the outer JoinClause
-			buf.WriteString(y.Y.String())
-
-			// Add the constraint for the outer JoinClause
-			if y.Constraint != nil {
-				fmt.Fprintf(&buf, " %s", y.Constraint.String())
-			}
-		} else {
-			// Handle the singly-nested case
-
-			// Print the left side of the nested JoinClause
-			buf.WriteString(y.X.String())
-
-			// Add the constraint for the first join
-			if c.Constraint != nil {
-				fmt.Fprintf(&buf, " %s", c.Constraint.String())
-			}
-
-			// Print the operator of the nested JoinClause
-			buf.WriteString(y.Operator.String())
-
-			// Print the right side of the nested JoinClause
-			buf.WriteString(y.Y.String())
-
-			// Add the constraint for the nested JoinClause
-			if y.Constraint != nil {
-				fmt.Fprintf(&buf, " %s", y.Constraint.String())
-			}
-		}
-	} else {
-		// Normal case: right side is not a JoinClause
-		buf.WriteString(c.Y.String())
-
-		// Add the constraint
-		if c.Constraint != nil {
-			fmt.Fprintf(&buf, " %s", c.Constraint.String())
-		}
+	buf.WriteString(c.Y.String())
+	if c.Constraint != nil {
+		fmt.Fprintf(&buf, " %s", c.Constraint.String())
 	}
-
 	return buf.String()
 }
 

--- a/ast_test.go
+++ b/ast_test.go
@@ -815,61 +815,112 @@ func TestSelectStatement_String(t *testing.T) {
 		},
 		From: pos(9),
 		Source: &sql.JoinClause{
-			X: &sql.QualifiedTableName{
-				Name:  &sql.Ident{NamePos: pos(14), Name: "X"},
-				As:    pos(16),
-				Alias: &sql.Ident{NamePos: pos(19), Name: "a"},
-			},
-			Operator: &sql.JoinOperator{Join: pos(21)},
-			Y: &sql.JoinClause{
+			X: &sql.JoinClause{
 				X: &sql.QualifiedTableName{
+					Name:  &sql.Ident{NamePos: pos(14), Name: "X"},
+					As:    pos(16),
+					Alias: &sql.Ident{NamePos: pos(19), Name: "a"},
+				},
+				Operator: &sql.JoinOperator{Join: pos(21)},
+				Y: &sql.QualifiedTableName{
 					Name:  &sql.Ident{NamePos: pos(26), Name: "Y"},
 					As:    pos(28),
 					Alias: &sql.Ident{NamePos: pos(31), Name: "b"},
 				},
-				Operator: &sql.JoinOperator{Join: pos(48)},
-				Y: &sql.QualifiedTableName{
-					Name:  &sql.Ident{NamePos: pos(53), Name: "Z"},
-					As:    pos(55),
-					Alias: &sql.Ident{NamePos: pos(58), Name: "c"},
-				},
 				Constraint: &sql.OnConstraint{
-					On: pos(60),
+					On: pos(33),
 					X: &sql.BinaryExpr{
 						X: &sql.QualifiedRef{
-							Table:  &sql.Ident{NamePos: pos(63), Name: "b"},
-							Dot:    pos(64),
-							Column: &sql.Ident{NamePos: pos(65), Name: "id"},
+							Table:  &sql.Ident{NamePos: pos(36), Name: "a"},
+							Dot:    pos(37),
+							Column: &sql.Ident{NamePos: pos(38), Name: "id"},
 						},
-						OpPos: pos(68),
+						OpPos: pos(41),
 						Op:    sql.EQ,
 						Y: &sql.QualifiedRef{
-							Table:  &sql.Ident{NamePos: pos(70), Name: "c"},
-							Dot:    pos(71),
-							Column: &sql.Ident{NamePos: pos(72), Name: "id"},
+							Table:  &sql.Ident{NamePos: pos(43), Name: "b"},
+							Dot:    pos(44),
+							Column: &sql.Ident{NamePos: pos(45), Name: "id"},
 						},
 					},
 				},
 			},
+			Operator: &sql.JoinOperator{Join: pos(48)},
+			Y: &sql.QualifiedTableName{
+				Name:  &sql.Ident{NamePos: pos(53), Name: "Z"},
+				As:    pos(55),
+				Alias: &sql.Ident{NamePos: pos(58), Name: "c"},
+			},
 			Constraint: &sql.OnConstraint{
-				On: pos(33),
+				On: pos(60),
 				X: &sql.BinaryExpr{
 					X: &sql.QualifiedRef{
-						Table:  &sql.Ident{NamePos: pos(36), Name: "a"},
-						Dot:    pos(37),
-						Column: &sql.Ident{NamePos: pos(38), Name: "id"},
+						Table:  &sql.Ident{NamePos: pos(63), Name: "b"},
+						Dot:    pos(64),
+						Column: &sql.Ident{NamePos: pos(65), Name: "id"},
 					},
-					OpPos: pos(41),
+					OpPos: pos(68),
 					Op:    sql.EQ,
 					Y: &sql.QualifiedRef{
-						Table:  &sql.Ident{NamePos: pos(43), Name: "b"},
-						Dot:    pos(44),
-						Column: &sql.Ident{NamePos: pos(45), Name: "id"},
+						Table:  &sql.Ident{NamePos: pos(70), Name: "c"},
+						Dot:    pos(71),
+						Column: &sql.Ident{NamePos: pos(72), Name: "id"},
 					},
 				},
 			},
 		},
 	}, `SELECT * FROM "X" AS "a" JOIN "Y" AS "b" ON "a"."id" = "b"."id" JOIN "Z" AS "c" ON "b"."id" = "c"."id"`)
+
+	// 4-join: A JOIN B ON 1 JOIN C ON 2 JOIN D ON 3
+	AssertStatementStringer(t, &sql.SelectStatement{
+		Select:  pos(0),
+		Columns: []*sql.ResultColumn{{Star: pos(7)}},
+		From:    pos(9),
+		Source: &sql.JoinClause{
+			X: &sql.JoinClause{
+				X: &sql.JoinClause{
+					X:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(14), Name: "A"}},
+					Operator:   &sql.JoinOperator{Join: pos(16)},
+					Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(21), Name: "B"}},
+					Constraint: &sql.OnConstraint{On: pos(23), X: &sql.NumberLit{ValuePos: pos(26), Value: "1"}},
+				},
+				Operator:   &sql.JoinOperator{Join: pos(28)},
+				Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(33), Name: "C"}},
+				Constraint: &sql.OnConstraint{On: pos(35), X: &sql.NumberLit{ValuePos: pos(38), Value: "2"}},
+			},
+			Operator:   &sql.JoinOperator{Join: pos(40)},
+			Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(45), Name: "D"}},
+			Constraint: &sql.OnConstraint{On: pos(47), X: &sql.NumberLit{ValuePos: pos(50), Value: "3"}},
+		},
+	}, `SELECT * FROM "A" JOIN "B" ON 1 JOIN "C" ON 2 JOIN "D" ON 3`)
+
+	// 5-join: A JOIN B ON 1 JOIN C ON 2 JOIN D ON 3 JOIN E ON 4
+	AssertStatementStringer(t, &sql.SelectStatement{
+		Select:  pos(0),
+		Columns: []*sql.ResultColumn{{Star: pos(7)}},
+		From:    pos(9),
+		Source: &sql.JoinClause{
+			X: &sql.JoinClause{
+				X: &sql.JoinClause{
+					X: &sql.JoinClause{
+						X:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(14), Name: "A"}},
+						Operator:   &sql.JoinOperator{Join: pos(16)},
+						Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(21), Name: "B"}},
+						Constraint: &sql.OnConstraint{On: pos(23), X: &sql.NumberLit{ValuePos: pos(26), Value: "1"}},
+					},
+					Operator:   &sql.JoinOperator{Join: pos(28)},
+					Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(33), Name: "C"}},
+					Constraint: &sql.OnConstraint{On: pos(35), X: &sql.NumberLit{ValuePos: pos(38), Value: "2"}},
+				},
+				Operator:   &sql.JoinOperator{Join: pos(40)},
+				Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(45), Name: "D"}},
+				Constraint: &sql.OnConstraint{On: pos(47), X: &sql.NumberLit{ValuePos: pos(50), Value: "3"}},
+			},
+			Operator:   &sql.JoinOperator{Join: pos(52)},
+			Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(57), Name: "E"}},
+			Constraint: &sql.OnConstraint{On: pos(59), X: &sql.NumberLit{ValuePos: pos(62), Value: "4"}},
+		},
+	}, `SELECT * FROM "A" JOIN "B" ON 1 JOIN "C" ON 2 JOIN "D" ON 3 JOIN "E" ON 4`)
 }
 
 func TestUpdateStatement_String(t *testing.T) {

--- a/parser.go
+++ b/parser.go
@@ -2238,22 +2238,7 @@ func (p *Parser) parseSource() (source Source, err error) {
 			return source, err
 		}
 
-		// Rewrite last source to nest next join on right side.
-		if lhs, ok := source.(*JoinClause); ok {
-			source = &JoinClause{
-				X:        lhs.X,
-				Operator: lhs.Operator,
-				Y: &JoinClause{
-					X:          lhs.Y,
-					Operator:   operator,
-					Y:          y,
-					Constraint: constraint,
-				},
-				Constraint: lhs.Constraint,
-			}
-		} else {
-			source = &JoinClause{X: source, Operator: operator, Y: y, Constraint: constraint}
-		}
+		source = &JoinClause{X: source, Operator: operator, Y: y, Constraint: constraint}
 	}
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -2435,26 +2435,26 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 			From: pos(9),
 			Source: &sql.JoinClause{
-				X: &sql.QualifiedTableName{
-					Name: &sql.Ident{NamePos: pos(14), Name: "X"},
-				},
-				Operator: &sql.JoinOperator{Inner: pos(16), Join: pos(22)},
-				Y: &sql.JoinClause{
+				X: &sql.JoinClause{
 					X: &sql.QualifiedTableName{
+						Name: &sql.Ident{NamePos: pos(14), Name: "X"},
+					},
+					Operator: &sql.JoinOperator{Inner: pos(16), Join: pos(22)},
+					Y: &sql.QualifiedTableName{
 						Name: &sql.Ident{NamePos: pos(27), Name: "Y"},
 					},
-					Operator: &sql.JoinOperator{Inner: pos(37), Join: pos(43)},
-					Y: &sql.QualifiedTableName{
-						Name: &sql.Ident{NamePos: pos(48), Name: "Z"},
-					},
 					Constraint: &sql.OnConstraint{
-						On: pos(50),
-						X:  &sql.BoolLit{ValuePos: pos(53), Value: false},
+						On: pos(29),
+						X:  &sql.BoolLit{ValuePos: pos(32), Value: true},
 					},
 				},
+				Operator: &sql.JoinOperator{Inner: pos(37), Join: pos(43)},
+				Y: &sql.QualifiedTableName{
+					Name: &sql.Ident{NamePos: pos(48), Name: "Z"},
+				},
 				Constraint: &sql.OnConstraint{
-					On: pos(29),
-					X:  &sql.BoolLit{ValuePos: pos(32), Value: true},
+					On: pos(50),
+					X:  &sql.BoolLit{ValuePos: pos(53), Value: false},
 				},
 			},
 		})
@@ -2465,56 +2465,56 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 			From: pos(9),
 			Source: &sql.JoinClause{
-				X: &sql.QualifiedTableName{
-					Name:  &sql.Ident{NamePos: pos(14), Name: "X"},
-					As:    pos(16),
-					Alias: &sql.Ident{NamePos: pos(19), Name: "a"},
-				},
-				Operator: &sql.JoinOperator{Join: pos(21)},
-				Y: &sql.JoinClause{
+				X: &sql.JoinClause{
 					X: &sql.QualifiedTableName{
+						Name:  &sql.Ident{NamePos: pos(14), Name: "X"},
+						As:    pos(16),
+						Alias: &sql.Ident{NamePos: pos(19), Name: "a"},
+					},
+					Operator: &sql.JoinOperator{Join: pos(21)},
+					Y: &sql.QualifiedTableName{
 						Name:  &sql.Ident{NamePos: pos(26), Name: "Y"},
 						As:    pos(28),
 						Alias: &sql.Ident{NamePos: pos(31), Name: "b"},
 					},
-					Operator: &sql.JoinOperator{Join: pos(48)},
-					Y: &sql.QualifiedTableName{
-						Name:  &sql.Ident{NamePos: pos(53), Name: "Z"},
-						As:    pos(55),
-						Alias: &sql.Ident{NamePos: pos(58), Name: "c"},
-					},
 					Constraint: &sql.OnConstraint{
-						On: pos(60),
+						On: pos(33),
 						X: &sql.BinaryExpr{
 							X: &sql.QualifiedRef{
-								Table:  &sql.Ident{NamePos: pos(63), Name: "b"},
-								Dot:    pos(64),
-								Column: &sql.Ident{NamePos: pos(65), Name: "id"},
+								Table:  &sql.Ident{NamePos: pos(36), Name: "a"},
+								Dot:    pos(37),
+								Column: &sql.Ident{NamePos: pos(38), Name: "id"},
 							},
-							OpPos: pos(68),
+							OpPos: pos(41),
 							Op:    sql.EQ,
 							Y: &sql.QualifiedRef{
-								Table:  &sql.Ident{NamePos: pos(70), Name: "c"},
-								Dot:    pos(71),
-								Column: &sql.Ident{NamePos: pos(72), Name: "id"},
+								Table:  &sql.Ident{NamePos: pos(43), Name: "b"},
+								Dot:    pos(44),
+								Column: &sql.Ident{NamePos: pos(45), Name: "id"},
 							},
 						},
 					},
 				},
+				Operator: &sql.JoinOperator{Join: pos(48)},
+				Y: &sql.QualifiedTableName{
+					Name:  &sql.Ident{NamePos: pos(53), Name: "Z"},
+					As:    pos(55),
+					Alias: &sql.Ident{NamePos: pos(58), Name: "c"},
+				},
 				Constraint: &sql.OnConstraint{
-					On: pos(33),
+					On: pos(60),
 					X: &sql.BinaryExpr{
 						X: &sql.QualifiedRef{
-							Table:  &sql.Ident{NamePos: pos(36), Name: "a"},
-							Dot:    pos(37),
-							Column: &sql.Ident{NamePos: pos(38), Name: "id"},
+							Table:  &sql.Ident{NamePos: pos(63), Name: "b"},
+							Dot:    pos(64),
+							Column: &sql.Ident{NamePos: pos(65), Name: "id"},
 						},
-						OpPos: pos(41),
+						OpPos: pos(68),
 						Op:    sql.EQ,
 						Y: &sql.QualifiedRef{
-							Table:  &sql.Ident{NamePos: pos(43), Name: "b"},
-							Dot:    pos(44),
-							Column: &sql.Ident{NamePos: pos(45), Name: "id"},
+							Table:  &sql.Ident{NamePos: pos(70), Name: "c"},
+							Dot:    pos(71),
+							Column: &sql.Ident{NamePos: pos(72), Name: "id"},
 						},
 					},
 				},
@@ -2559,20 +2559,20 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 			From: pos(9),
 			Source: &sql.JoinClause{
-				X:        &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(14), Name: "A"}},
-				Operator: &sql.JoinOperator{Join: pos(16)},
-				Y: &sql.JoinClause{
+				X: &sql.JoinClause{
 					X: &sql.JoinClause{
-						X:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(21), Name: "B"}},
-						Operator:   &sql.JoinOperator{Join: pos(28)},
-						Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(33), Name: "C"}},
-						Constraint: &sql.OnConstraint{On: pos(35), X: &sql.NumberLit{ValuePos: pos(38), Value: "2"}},
+						X:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(14), Name: "A"}},
+						Operator:   &sql.JoinOperator{Join: pos(16)},
+						Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(21), Name: "B"}},
+						Constraint: &sql.OnConstraint{On: pos(23), X: &sql.NumberLit{ValuePos: pos(26), Value: "1"}},
 					},
-					Operator:   &sql.JoinOperator{Join: pos(40)},
-					Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(45), Name: "D"}},
-					Constraint: &sql.OnConstraint{On: pos(47), X: &sql.NumberLit{ValuePos: pos(50), Value: "3"}},
+					Operator:   &sql.JoinOperator{Join: pos(28)},
+					Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(33), Name: "C"}},
+					Constraint: &sql.OnConstraint{On: pos(35), X: &sql.NumberLit{ValuePos: pos(38), Value: "2"}},
 				},
-				Constraint: &sql.OnConstraint{On: pos(23), X: &sql.NumberLit{ValuePos: pos(26), Value: "1"}},
+				Operator:   &sql.JoinOperator{Join: pos(40)},
+				Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(45), Name: "D"}},
+				Constraint: &sql.OnConstraint{On: pos(47), X: &sql.NumberLit{ValuePos: pos(50), Value: "3"}},
 			},
 		})
 		AssertParseStatement(t, `SELECT * FROM A JOIN B ON 1 JOIN C ON 2 JOIN D ON 3 JOIN E ON 4`, &sql.SelectStatement{
@@ -2582,25 +2582,25 @@ func TestParser_ParseStatement(t *testing.T) {
 			},
 			From: pos(9),
 			Source: &sql.JoinClause{
-				X:        &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(14), Name: "A"}},
-				Operator: &sql.JoinOperator{Join: pos(16)},
-				Y: &sql.JoinClause{
+				X: &sql.JoinClause{
 					X: &sql.JoinClause{
 						X: &sql.JoinClause{
-							X:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(21), Name: "B"}},
-							Operator:   &sql.JoinOperator{Join: pos(28)},
-							Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(33), Name: "C"}},
-							Constraint: &sql.OnConstraint{On: pos(35), X: &sql.NumberLit{ValuePos: pos(38), Value: "2"}},
+							X:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(14), Name: "A"}},
+							Operator:   &sql.JoinOperator{Join: pos(16)},
+							Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(21), Name: "B"}},
+							Constraint: &sql.OnConstraint{On: pos(23), X: &sql.NumberLit{ValuePos: pos(26), Value: "1"}},
 						},
-						Operator:   &sql.JoinOperator{Join: pos(40)},
-						Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(45), Name: "D"}},
-						Constraint: &sql.OnConstraint{On: pos(47), X: &sql.NumberLit{ValuePos: pos(50), Value: "3"}},
+						Operator:   &sql.JoinOperator{Join: pos(28)},
+						Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(33), Name: "C"}},
+						Constraint: &sql.OnConstraint{On: pos(35), X: &sql.NumberLit{ValuePos: pos(38), Value: "2"}},
 					},
-					Operator:   &sql.JoinOperator{Join: pos(52)},
-					Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(57), Name: "E"}},
-					Constraint: &sql.OnConstraint{On: pos(59), X: &sql.NumberLit{ValuePos: pos(62), Value: "4"}},
+					Operator:   &sql.JoinOperator{Join: pos(40)},
+					Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(45), Name: "D"}},
+					Constraint: &sql.OnConstraint{On: pos(47), X: &sql.NumberLit{ValuePos: pos(50), Value: "3"}},
 				},
-				Constraint: &sql.OnConstraint{On: pos(23), X: &sql.NumberLit{ValuePos: pos(26), Value: "1"}},
+				Operator:   &sql.JoinOperator{Join: pos(52)},
+				Y:          &sql.QualifiedTableName{Name: &sql.Ident{NamePos: pos(57), Name: "E"}},
+				Constraint: &sql.OnConstraint{On: pos(59), X: &sql.NumberLit{ValuePos: pos(62), Value: "4"}},
 			},
 		})
 


### PR DESCRIPTION
The parser previously built a right-nested tree for multi-way JOINs, which separated each ON constraint from its corresponding join and required a complex writeJoinClause() helper to reassemble the correct SQL output. This broke for 4+ joins.

Switch to left-nested trees matching SQL's left-associative semantics, so each constraint stays with its join and String() becomes trivially recursive.